### PR TITLE
fix: 選択済み添付ファイルのクリックでサムネイルが消える問題を修正

### DIFF
--- a/resources/js/features/attachments/AttachmentTable.tsx
+++ b/resources/js/features/attachments/AttachmentTable.tsx
@@ -147,7 +147,7 @@ export const AttachmentTable = ({
                     ? "cursor-pointer v2-selected-bg"
                     : "cursor-pointer v2-hover-bg-sub")
               )}
-              onClick={() => onSelectAttachment?.(selected === a.id ? null : a)}
+              onClick={() => onSelectAttachment?.(a)}
             >
               <td>
                 <Image

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithAuthentication;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithConsole;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Sleep;
 use Mockery;
@@ -19,8 +20,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
  */
 abstract class TestCase extends BaseTestCase
 {
-    use \Illuminate\Foundation\Testing\Concerns\InteractsWithConsole,
-        \Illuminate\Foundation\Testing\Concerns\InteractsWithContainer,
+    use \Illuminate\Foundation\Testing\Concerns\InteractsWithContainer,
         \Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling,
         \Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling,
         \Illuminate\Foundation\Testing\Concerns\InteractsWithSession,
@@ -28,7 +28,8 @@ abstract class TestCase extends BaseTestCase
         \Illuminate\Foundation\Testing\Concerns\InteractsWithTime,
         \Illuminate\Foundation\Testing\Concerns\InteractsWithViews,
         \Illuminate\Foundation\Testing\Concerns\MakesHttpRequests,
-        InteractsWithAuthentication;
+        InteractsWithAuthentication,
+        InteractsWithConsole;
 
     /**
      * The list of trait that this test uses, fetched recursively.


### PR DESCRIPTION
## Summary

- `AttachmentTable` で選択済みのファイルをクリックすると `null` を渡すトグル動作が、サムネイル・アバター・ファイルを意図せずクリアしていた
- 添付ファイル選択モーダルはクリック直後に閉じるため、ユーザーは「選択を確定した」と認識するが内部では解除されていた
- クリックは常に選択確定として扱うよう1行を修正

## 再現手順

1. 既公開アドオンの編集画面を開く
2. 「アップロード済みの画像から選択」モーダルを開く（現在のサムネイルがハイライト表示）
3. そのサムネイル画像をクリックする
4. 保存 → サムネイルが "no image" になる

## 原因

`AttachmentTable.tsx` のクリックハンドラが既選択アイテムに対して `null` を渡していた:

```js
// 修正前
onClick={() => onSelectAttachment?.(selected === a.id ? null : a)}

// 修正後
onClick={() => onSelectAttachment?.(a)}
```

影響箇所: サムネイル選択・ファイル選択・プロフィールアバター選択・セクション画像選択

## Test plan

- [ ] 既存サムネイルがある記事を編集し、モーダルで同じサムネイルをクリックして保存 → サムネイルが維持されることを確認
- [ ] 別の画像に変更して保存 → 新しいサムネイルに更新されることを確認
- [ ] サムネイルなしの状態で画像を選択して保存 → サムネイルが設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)