### PR TITLE
refactor: Pakパーサーのバージョン検出とint64読み取りを共通化

### DIFF
--- a/app/Services/FileInfo/Extractors/Pak/BinaryReader.php
+++ b/app/Services/FileInfo/Extractors/Pak/BinaryReader.php
@@ -82,6 +82,35 @@ class BinaryReader
         return $result[1];
     }
 
+    public function readSint64LE(): int
+    {
+        if (! $this->hasMore(8)) {
+            throw InvalidPakFileException::unexpectedEof();
+        }
+
+        $result = unpack('P', substr($this->binary, $this->position, 8));
+        if ($result === false) {
+            throw new OutOfBoundsException('Failed to read sint64');
+        }
+
+        $this->position += 8;
+
+        return $result[1];
+    }
+
+    /**
+     * Read a signed 64-bit integer at a fixed offset (for non-sequential parsers).
+     */
+    public static function unpackSint64(string $data, int $offset): int
+    {
+        $result = unpack('P', substr($data, $offset, 8));
+        if ($result === false) {
+            throw new OutOfBoundsException('Failed to read sint64 at offset '.$offset);
+        }
+
+        return $result[1];
+    }
+
     public function readString(int $length): string
     {
         if (! $this->hasMore($length)) {

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/BridgeParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/BridgeParser.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -28,35 +30,27 @@ class BridgeParser implements TypeParserInterface
         $binaryData = $node->data;
         $offset = 0;
 
-        // Read first uint16 to determine version
-        $firstUint16Data = unpack('v', substr($binaryData, $offset, 2));
-        if ($firstUint16Data === false) {
-            throw new RuntimeException('Failed to read bridge version/waytype');
-        }
+        $stamp = VersionStamp::from($binaryData, $offset);
 
-        $firstUint16 = $firstUint16Data[1];
-
-        // Check if high bit is set (versioned format)
-        if (($firstUint16 & 0x8000) !== 0) {
-            $version = $firstUint16 & 0x7FFF; // Mask out high bit
+        if ($stamp->isVersioned) {
             $offset += 2;
 
-            return match ($version) {
+            return match ($stamp->version) {
                 1 => $this->parseVersion1($binaryData, $offset),
                 2 => $this->parseVersion2($binaryData, $offset),
                 3 => $this->parseVersion3($binaryData, $offset),
                 4 => $this->parseVersion4($binaryData, $offset),
                 5 => $this->parseVersion5($binaryData, $offset),
                 6 => $this->parseVersion6($binaryData, $offset),
-                7, 8 => $this->parseVersion7And8($binaryData, $offset, $version),
+                7, 8 => $this->parseVersion7And8($binaryData, $offset, $stamp->version),
                 9 => $this->parseVersion9($binaryData, $offset),
                 10 => $this->parseVersion10($binaryData, $offset),
-                default => throw new RuntimeException('Unsupported bridge version: '.$version),
+                default => throw new RuntimeException('Unsupported bridge version: '.$stamp->version),
             };
         }
 
         // Version 0 (legacy format): firstUint16 is actually waytype
-        return $this->parseVersion0($binaryData, $offset, $firstUint16);
+        return $this->parseVersion0($binaryData, $offset, $stamp->firstUint16);
     }
 
     /**
@@ -546,11 +540,11 @@ class BridgeParser implements TypeParserInterface
         $offset += 2;
 
         // price (sint64) - CHANGED in version 10
-        $result['price'] = $this->readInt64($binaryData, $offset);
+        $result['price'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // maintenance (sint64) - CHANGED in version 10
-        $result['maintenance'] = $this->readInt64($binaryData, $offset);
+        $result['maintenance'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // wtyp (uint8)
@@ -634,19 +628,6 @@ class BridgeParser implements TypeParserInterface
         $result['number_of_seasons'] = $seasonsData[1];
 
         return $this->buildResult($result);
-    }
-
-    /**
-     * Read signed 64-bit integer (little-endian)
-     */
-    private function readInt64(string $binaryData, int $offset): int
-    {
-        $data = unpack('P', substr($binaryData, $offset, 8));
-        if ($data === false) {
-            throw new RuntimeException('Failed to read int64');
-        }
-
-        return $data[1];
     }
 
     /**

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/CitycarParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/CitycarParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -34,28 +35,19 @@ class CitycarParser implements TypeParserInterface
         $binaryData = $node->data;
         $offset = 0;
 
-        // Read first uint16
-        $firstUint16Data = unpack('v', substr($binaryData, $offset, 2));
-        if ($firstUint16Data === false) {
-            throw new RuntimeException('Failed to read citycar version/weight');
-        }
-
-        $firstUint16 = $firstUint16Data[1];
+        $stamp = VersionStamp::from($binaryData, $offset);
         $offset += 2;
 
-        // Check if high bit is set (versioned format)
-        if (($firstUint16 & 0x8000) !== 0) {
-            $version = $firstUint16 & 0x7FFF;
-
-            return match ($version) {
+        if ($stamp->isVersioned) {
+            return match ($stamp->version) {
                 1 => $this->parseVersion1($binaryData, $offset),
                 2 => $this->parseVersion2($binaryData, $offset),
-                default => throw new RuntimeException('Unsupported citycar version: '.$version),
+                default => throw new RuntimeException('Unsupported citycar version: '.$stamp->version),
             };
         }
 
         // Version 0 (legacy): firstUint16 is distribution_weight
-        return $this->parseVersion0($firstUint16);
+        return $this->parseVersion0($stamp->firstUint16);
     }
 
     /**

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/CrossingParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/CrossingParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -31,27 +32,17 @@ class CrossingParser implements TypeParserInterface
         $binaryData = $node->data;
         $offset = 0;
 
-        // Read first uint16
-        $firstUint16Data = unpack('v', substr($binaryData, $offset, 2));
-        if ($firstUint16Data === false) {
-            throw new RuntimeException('Failed to read crossing version');
-        }
-
-        $firstUint16 = $firstUint16Data[1];
+        $stamp = VersionStamp::from($binaryData, $offset);
         $offset += 2;
 
-        // Check if high bit is set (versioned format)
-        if (($firstUint16 & 0x8000) === 0) {
-            // Version 0 (legacy): Not supported
+        if (! $stamp->isVersioned) {
             throw new RuntimeException('Crossing version 0 (legacy) is not supported');
         }
 
-        $version = $firstUint16 & 0x7FFF;
-
-        return match ($version) {
+        return match ($stamp->version) {
             1 => $this->parseVersion1($binaryData, $offset),
             2 => $this->parseVersion2($binaryData, $offset),
-            default => throw new RuntimeException('Unsupported crossing version: '.$version),
+            default => throw new RuntimeException('Unsupported crossing version: '.$stamp->version),
         };
     }
 

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/FactoryParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/FactoryParser.php
@@ -7,6 +7,7 @@ namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 use App\Services\FileInfo\Extractors\Pak\Node;
 use App\Services\FileInfo\Extractors\Pak\ObjectTypeConverter;
 use App\Services\FileInfo\Extractors\Pak\TextNodeExtractor;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -33,30 +34,21 @@ class FactoryParser implements TypeParserInterface
         $binaryData = $node->data;
         $offset = 0;
 
-        // Read first uint16
-        $firstUint16Data = unpack('v', substr($binaryData, $offset, 2));
-        if ($firstUint16Data === false) {
-            throw new RuntimeException('Failed to read factory version/placement');
-        }
-
-        $firstUint16 = $firstUint16Data[1];
+        $stamp = VersionStamp::from($binaryData, $offset);
         $offset += 2;
 
-        // Check if high bit is set (versioned format)
-        if (($firstUint16 & 0x8000) !== 0) {
-            $version = $firstUint16 & 0x7FFF;
-
-            $result = match ($version) {
+        if ($stamp->isVersioned) {
+            $result = match ($stamp->version) {
                 1 => $this->parseVersion1($binaryData, $offset),
                 2 => $this->parseVersion2($binaryData, $offset),
                 3 => $this->parseVersion3($binaryData, $offset),
                 4 => $this->parseVersion4($binaryData, $offset),
                 5 => $this->parseVersion5($binaryData, $offset),
-                default => throw new RuntimeException('Unsupported factory version: '.$version),
+                default => throw new RuntimeException('Unsupported factory version: '.$stamp->version),
             };
         } else {
             // Version 0 (legacy): firstUint16 is placement type
-            $result = $this->parseVersion0($binaryData, $offset, $firstUint16);
+            $result = $this->parseVersion0($binaryData, $offset, $stamp->firstUint16);
         }
 
         // Extract input data from FSUP (factory supplier) child nodes

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/GoodParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/GoodParser.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
 use App\Services\FileInfo\Extractors\Pak\Node;
 use App\Services\FileInfo\Extractors\Pak\TextNodeExtractor;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -39,29 +41,20 @@ class GoodParser implements TypeParserInterface
         $binaryData = $node->data;
         $offset = 0;
 
-        // Read first uint16
-        $firstUint16Data = unpack('v', substr($binaryData, $offset, 2));
-        if ($firstUint16Data === false) {
-            throw new RuntimeException('Failed to read goods version/value');
-        }
+        $stamp = VersionStamp::from($binaryData, $offset);
 
-        $firstUint16 = $firstUint16Data[1];
-
-        // Check if high bit is set (versioned format)
-        if (($firstUint16 & 0x8000) !== 0) {
-            $version = $firstUint16 & 0x7FFF; // Mask out high bit
+        if ($stamp->isVersioned) {
             $offset += 2;
-
-            $result = match ($version) {
+            $result = match ($stamp->version) {
                 1 => $this->parseVersion1($binaryData, $offset),
                 2 => $this->parseVersion2($binaryData, $offset),
                 3 => $this->parseVersion3($binaryData, $offset),
                 4 => $this->parseVersion4($binaryData, $offset),
-                default => throw new RuntimeException('Unsupported goods version: '.$version),
+                default => throw new RuntimeException('Unsupported goods version: '.$stamp->version),
             };
         } else {
             // Version 0 (legacy format): firstUint16 is actually base_value
-            $result = $this->parseVersion0($binaryData, $offset, $firstUint16);
+            $result = $this->parseVersion0($binaryData, $offset, $stamp->firstUint16);
         }
 
         // Add metric to result
@@ -258,7 +251,7 @@ class GoodParser implements TypeParserInterface
         $result = ['version' => 4];
 
         // base_value (sint64) - CHANGED in version 4
-        $result['base_value'] = $this->readInt64($binaryData, $offset);
+        $result['base_value'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // catg (uint8)
@@ -297,19 +290,6 @@ class GoodParser implements TypeParserInterface
         $result['color'] = $colorData[1];
 
         return $this->buildResult($result);
-    }
-
-    /**
-     * Read signed 64-bit integer (little-endian)
-     */
-    private function readInt64(string $binaryData, int $offset): int
-    {
-        $data = unpack('P', substr($binaryData, $offset, 8));
-        if ($data === false) {
-            throw new RuntimeException('Failed to read int64');
-        }
-
-        return $data[1];
     }
 
     /**

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/GroundobjParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/GroundobjParser.php
@@ -6,6 +6,7 @@ namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
 use App\Enums\SimutransClimate;
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -49,14 +50,13 @@ class GroundobjParser implements TypeParserInterface
      */
     public function parse(Node $node): array
     {
-        $firstUint16 = (unpack('v', substr($node->data, 0, 2)) ?: [])[1] ?? 0;
-        $version = (($firstUint16 & 0x8000) !== 0) ? ($firstUint16 & 0x7FFF) : 0;
+        $stamp = VersionStamp::from($node->data);
 
-        $result = match ($version) {
+        $result = match ($stamp->version) {
             0 => throw new RuntimeException('Groundobj version 0 does not exist'),
             1 => $this->parseVersion1($node->data),
             2 => $this->parseVersion2($node->data),
-            default => throw new RuntimeException('Unsupported groundobj version: '.$version),
+            default => throw new RuntimeException('Unsupported groundobj version: '.$stamp->version),
         };
 
         return $this->buildResult($result);

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/PedestrianParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/PedestrianParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -40,14 +41,13 @@ class PedestrianParser implements TypeParserInterface
      */
     public function parse(Node $node): array
     {
-        $firstUint16 = (unpack('v', substr($node->data, 0, 2)) ?: [])[1] ?? 0;
-        $version = (($firstUint16 & 0x8000) !== 0) ? ($firstUint16 & 0x7FFF) : 0;
+        $stamp = VersionStamp::from($node->data);
 
-        return match ($version) {
-            0 => $this->parseVersion0($firstUint16),
+        return match ($stamp->version) {
+            0 => $this->parseVersion0($stamp->firstUint16),
             1 => $this->parseVersion1($node->data),
             2 => $this->parseVersion2($node->data),
-            default => throw new RuntimeException('Unsupported pedestrian version: '.$version),
+            default => throw new RuntimeException('Unsupported pedestrian version: '.$stamp->version),
         };
     }
 

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/SignParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/SignParser.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -45,30 +47,22 @@ class SignParser implements TypeParserInterface
         $binaryData = $node->data;
         $offset = 0;
 
-        // Read first uint16 to determine version
-        $firstUint16Data = unpack('v', substr($binaryData, $offset, 2));
-        if ($firstUint16Data === false) {
-            throw new RuntimeException('Failed to read roadsign version');
-        }
+        $stamp = VersionStamp::from($binaryData, $offset);
 
-        $firstUint16 = $firstUint16Data[1];
-
-        // Check if high bit is set (versioned format)
-        if (($firstUint16 & 0x8000) === 0) {
+        if (! $stamp->isVersioned) {
             throw new RuntimeException('Roadsign version 0 (legacy) is not supported');
         }
 
-        $version = $firstUint16 & 0x7FFF; // Mask out high bit
         $offset += 2;
 
-        return match ($version) {
+        return match ($stamp->version) {
             1 => $this->parseVersion1($binaryData, $offset),
             2 => $this->parseVersion2($binaryData, $offset),
             3 => $this->parseVersion3($binaryData, $offset),
             4 => $this->parseVersion4($binaryData, $offset),
             5 => $this->parseVersion5($binaryData, $offset),
             6 => $this->parseVersion6($binaryData, $offset),
-            default => throw new RuntimeException('Unsupported roadsign version: '.$version),
+            default => throw new RuntimeException('Unsupported roadsign version: '.$stamp->version),
         };
     }
 
@@ -396,11 +390,11 @@ class SignParser implements TypeParserInterface
         $offset += 2;
 
         // price (sint64) - CHANGED in version 6
-        $result['price'] = $this->readInt64($binaryData, $offset);
+        $result['price'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // maintenance (sint64) - NEW in version 6
-        $result['maintenance'] = $this->readInt64($binaryData, $offset);
+        $result['maintenance'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // flags (uint16)
@@ -448,19 +442,6 @@ class SignParser implements TypeParserInterface
         $result['retire_date'] = $retireDateData[1];
 
         return $this->buildResult($result);
-    }
-
-    /**
-     * Read signed 64-bit integer (little-endian)
-     */
-    private function readInt64(string $binaryData, int $offset): int
-    {
-        $data = unpack('P', substr($binaryData, $offset, 8));
-        if ($data === false) {
-            throw new RuntimeException('Failed to read int64');
-        }
-
-        return $data[1];
     }
 
     /**

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/SoundParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/SoundParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -41,14 +42,13 @@ class SoundParser implements TypeParserInterface
      */
     public function parse(Node $node): array
     {
-        $firstUint16 = (unpack('v', substr($node->data, 0, 2)) ?: [])[1] ?? 0;
-        $version = (($firstUint16 & 0x8000) !== 0) ? ($firstUint16 & 0x7FFF) : 0;
+        $stamp = VersionStamp::from($node->data);
 
-        return match ($version) {
+        return match ($stamp->version) {
             0 => throw new RuntimeException('Sound version 0 does not exist'),
             1 => $this->parseVersion1($node->data),
             2 => $this->parseVersion2($node->data),
-            default => throw new RuntimeException('Unsupported sound version: '.$version),
+            default => throw new RuntimeException('Unsupported sound version: '.$stamp->version),
         };
     }
 

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/TreeParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/TreeParser.php
@@ -6,6 +6,7 @@ namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
 use App\Enums\SimutransClimate;
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -53,14 +54,13 @@ class TreeParser implements TypeParserInterface
      */
     public function parse(Node $node): array
     {
-        $firstUint16 = (unpack('v', substr($node->data, 0, 2)) ?: [])[1] ?? 0;
-        $version = (($firstUint16 & 0x8000) !== 0) ? ($firstUint16 & 0x7FFF) : 0;
+        $stamp = VersionStamp::from($node->data);
 
-        $result = match ($version) {
+        $result = match ($stamp->version) {
             0 => $this->parseVersion0(),
             1 => $this->parseVersion1($node->data),
             2 => $this->parseVersion2($node->data),
-            default => throw new RuntimeException('Unsupported tree version: '.$version),
+            default => throw new RuntimeException('Unsupported tree version: '.$stamp->version),
         };
 
         return $this->buildResult($result);

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/TunnelParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/TunnelParser.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
 use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\VersionStamp;
 use RuntimeException;
 
 /**
@@ -28,30 +30,22 @@ class TunnelParser implements TypeParserInterface
         $binaryData = $node->data;
         $offset = 0;
 
-        // Read first uint16 to determine version
-        $firstUint16Data = unpack('v', substr($binaryData, $offset, 2));
-        if ($firstUint16Data === false) {
-            throw new RuntimeException('Failed to read tunnel version');
-        }
+        $stamp = VersionStamp::from($binaryData, $offset);
 
-        $firstUint16 = $firstUint16Data[1];
-
-        // Check if high bit is set (versioned format)
-        if (($firstUint16 & 0x8000) === 0) {
+        if (! $stamp->isVersioned) {
             throw new RuntimeException('Tunnel version 0 (legacy) is not supported');
         }
 
-        $version = $firstUint16 & 0x7FFF; // Mask out high bit
         $offset += 2;
 
-        return match ($version) {
+        return match ($stamp->version) {
             1 => $this->parseVersion1($binaryData, $offset),
             2 => $this->parseVersion2($binaryData, $offset),
             3 => $this->parseVersion3($binaryData, $offset),
             4 => $this->parseVersion4($binaryData, $offset),
             5 => $this->parseVersion5($binaryData, $offset),
             6 => $this->parseVersion6($binaryData, $offset),
-            default => throw new RuntimeException('Unsupported tunnel version: '.$version),
+            default => throw new RuntimeException('Unsupported tunnel version: '.$stamp->version),
         };
     }
 
@@ -507,11 +501,11 @@ class TunnelParser implements TypeParserInterface
         $offset += 4;
 
         // price (sint64) - CHANGED in version 6
-        $result['price'] = $this->readInt64($binaryData, $offset);
+        $result['price'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // maintenance (sint64) - CHANGED in version 6
-        $result['maintenance'] = $this->readInt64($binaryData, $offset);
+        $result['maintenance'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // wtyp (uint8)
@@ -577,19 +571,6 @@ class TunnelParser implements TypeParserInterface
         $result['broad_portals'] = $broadPortalsData[1] !== 0;
 
         return $this->buildResult($result);
-    }
-
-    /**
-     * Read signed 64-bit integer (little-endian)
-     */
-    private function readInt64(string $binaryData, int $offset): int
-    {
-        $data = unpack('P', substr($binaryData, $offset, 8));
-        if ($data === false) {
-            throw new RuntimeException('Failed to read int64');
-        }
-
-        return $data[1];
     }
 
     /**

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/WayObjectParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/WayObjectParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\FileInfo\Extractors\Pak\TypeParsers;
 
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
 use App\Services\FileInfo\Extractors\Pak\Node;
 use RuntimeException;
 
@@ -136,11 +137,11 @@ class WayObjectParser implements TypeParserInterface
         $result = ['version' => 2];
 
         // price (sint64)
-        $result['price'] = $this->readInt64($binaryData, $offset);
+        $result['price'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // maintenance (sint64)
-        $result['maintenance'] = $this->readInt64($binaryData, $offset);
+        $result['maintenance'] = BinaryReader::unpackSint64($binaryData, $offset);
         $offset += 8;
 
         // topspeed (uint32)
@@ -188,19 +189,6 @@ class WayObjectParser implements TypeParserInterface
         $result['own_waytype'] = $ownWtypData[1];
 
         return $this->buildResult($result);
-    }
-
-    /**
-     * Read signed 64-bit integer (little-endian)
-     */
-    private function readInt64(string $binaryData, int $offset): int
-    {
-        $data = unpack('P', substr($binaryData, $offset, 8));
-        if ($data === false) {
-            throw new RuntimeException('Failed to read int64');
-        }
-
-        return $data[1];
     }
 
     /**

--- a/app/Services/FileInfo/Extractors/Pak/VersionStamp.php
+++ b/app/Services/FileInfo/Extractors/Pak/VersionStamp.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\FileInfo\Extractors\Pak;
+
+/**
+ * Extracts versioned format stamp from pak binary data.
+ *
+ * Pak nodes store a version stamp as the first uint16:
+ * - If the high bit (0x8000) is set: bits 0-14 are the version number (versioned format)
+ * - Otherwise: the entire uint16 is a legacy field value (version 0)
+ */
+final class VersionStamp
+{
+    public function __construct(
+        public readonly int $version,
+        public readonly int $firstUint16,
+        public readonly bool $isVersioned,
+    ) {}
+
+    public static function from(string $data, int $offset = 0): self
+    {
+        $result = unpack('v', substr($data, $offset, 2));
+        if ($result === false) {
+            return new self(version: 0, firstUint16: 0, isVersioned: false);
+        }
+        $v = $result[1];
+        $isVersioned = ($v & 0x8000) !== 0;
+
+        return new self(
+            version: $isVersioned ? ($v & 0x7FFF) : 0,
+            firstUint16: $v,
+            isVersioned: $isVersioned,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `VersionStamp` クラスを新設し、パーサー間で重複していたバージョンスタンプ読み取り処理（高ビット `0x8000` チェック）を共通化
- `BinaryReader` に `readSint64LE()` インスタンスメソッドと `unpackSint64()` 静的メソッドを追加
- Bridge / Tunnel / Sign / Good / WayObject の 5 パーサーから同一内容の `readInt64()` private メソッドを除去
- 11 パーサーでバージョン検出コードを `VersionStamp::from()` で置き換え

変更量: 185行削除 / 137行追加（新ファイル込み）でネット -48行

## Test plan

- [ ] `npm run all` 通過（lint / types / phpstan / 529 feature tests / 226 unit tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)