### PR TITLE
refactor: Article model - remove dead scopeUser scope

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -72,7 +72,6 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Article query()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Article slug(string $slug)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Article tag(\App\Models\Tag $tag)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Article user(\App\Models\User $user)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Article withTrashed(bool $withTrashed = true)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Article withUserTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Article withoutAnnounce()

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -101,7 +101,6 @@ use Spatie\Feed\FeedItem;
  * @method static Builder<static>|Article query()
  * @method static Builder<static>|Article slug(string $slug)
  * @method static Builder<static>|Article tag(\App\Models\Tag $tag)
- * @method static Builder<static>|Article user(\App\Models\User $user)
  * @method static Builder<static>|Article withTrashed(bool $withTrashed = true)
  * @method static Builder<static>|Article withUserTrashed()
  * @method static Builder<static>|Article withoutAnnounce()
@@ -301,14 +300,6 @@ class Article extends Model implements Feedable
     protected function withUserTrashed(Builder $builder): void
     {
         $builder->withoutGlobalScope('WithoutTrashedUser');
-    }
-
-    /**
-     * @param  Builder<Article>  $builder
-     */
-    protected function scopeUser(Builder $builder, User $user): void
-    {
-        $builder->where('user_id', $user->id);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove `scopeUser()` from `Article` model — confirmed dead code (never called anywhere in app code)
- Remove corresponding `@method` docblock entry

## Notes

Attempted to convert `Slugable::setSlugAttribute` to `Attribute::make()` (new mutator style), but it causes a runtime conflict: defining `slug(): Attribute` on the model means `Article::slug($value)` via `__callStatic` calls the instance method directly, returning an `Attribute` object instead of a query Builder. The old-style `setSlugAttribute` is kept as-is.

## Test plan

- [x] All 755 tests pass
- [x] `npm run all` (lint + type checks + tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)