### PR TITLE
refactor: P2-7 フロントエンド状態管理の整理 - useMyListsフック抽出

### DIFF
--- a/resources/js/features/mylist/AddToMyList.tsx
+++ b/resources/js/features/mylist/AddToMyList.tsx
@@ -1,10 +1,11 @@
 import axios from "axios";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Button from "@/components/ui/Button";
 import { Modal } from "@/components/ui/Modal";
 import Input from "@/components/ui/Input";
 import TextBadge from "@/components/ui/TextBadge";
 import { useApiCall } from "@/hooks/useApiCall";
+import { useMyLists } from "@/hooks/useMyLists";
 import type { MyListShow, MyListCreateRequest } from "@/types/models";
 
 interface AddToMyListButtonProps {
@@ -75,35 +76,12 @@ const AddToMyListModal = ({
   onSuccess,
 }: AddToMyListModalProps) => {
   const { call } = useApiCall();
-  const [lists, setLists] = useState<MyListShow[]>([]);
+  const { lists, setLists, isLoading, error, setError } = useMyLists();
   const [selectedListIds, setSelectedListIds] = useState<Set<number>>(
     new Set()
   );
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [newListTitle, setNewListTitle] = useState("");
-
-  // リスト一覧を取得
-  useEffect(() => {
-    const fetchLists = async () => {
-      try {
-        setIsLoading(true);
-        const { data } = await axios.get("/api/v1/mylist");
-        if (Array.isArray(data.data)) {
-          setLists(data.data);
-        } else {
-          throw new Error("リストの取得に失敗しました");
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "エラーが発生しました");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchLists();
-  }, []);
 
   const handleToggleList = (listId: number) => {
     const newSelected = new Set(selectedListIds);

--- a/resources/js/hooks/useMyLists.ts
+++ b/resources/js/hooks/useMyLists.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+import { useState, useEffect, useCallback } from "react";
+import { extractErrorMessage } from "@/lib/errorHandler";
+import type { MyListShow } from "@/types/models";
+
+/**
+ * 自分のマイリスト一覧を取得・管理するフック。
+ * AddToMyListModal と MyListIndexPage で共有される。
+ */
+export const useMyLists = () => {
+  const [lists, setLists] = useState<MyListShow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLists = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const { data } = await axios.get("/api/v1/mylist");
+      if (Array.isArray(data.data)) {
+        setLists(data.data);
+      } else {
+        throw new Error("リストの取得に失敗しました");
+      }
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLists();
+  }, [fetchLists]);
+
+  return { lists, setLists, isLoading, error, setError, refetch: fetchLists };
+};

--- a/resources/js/mypage/pages/MyListIndexPage.tsx
+++ b/resources/js/mypage/pages/MyListIndexPage.tsx
@@ -1,9 +1,8 @@
-import axios from "axios";
 import { createRoot } from "react-dom/client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Button from "@/components/ui/Button";
 import { AppWrapper } from "../../components/AppWrapper";
-import { extractErrorMessage } from "@/lib/errorHandler";
+import { useMyLists } from "@/hooks/useMyLists";
 import {
   MyListTable,
   MyListEditModal,
@@ -16,34 +15,10 @@ const app = document.getElementById("app-mylist-index");
 if (app) {
   const App = () => {
     // 成功メッセージはモーダル内から showSuccess() で出力される
-    const [lists, setLists] = useState<MyListShow[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const { lists, isLoading, error, refetch } = useMyLists();
     const [editingList, setEditingList] = useState<MyListShow | null>(null);
     const [deletingList, setDeletingList] = useState<MyListShow | null>(null);
     const [isCreating, setIsCreating] = useState(false);
-
-    const fetchLists = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const { data } = await axios.get("/api/v1/mylist");
-        if (Array.isArray(data.data)) {
-          setLists(data.data);
-        } else {
-          throw new Error("リストの取得に失敗しました");
-        }
-      } catch (err) {
-        setError(extractErrorMessage(err));
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    useEffect(() => {
-      fetchLists();
-    }, []);
 
     const handleEdit = (list: MyListShow) => {
       setEditingList(list);
@@ -61,7 +36,7 @@ if (app) {
       setEditingList(null);
       setDeletingList(null);
       setIsCreating(false);
-      fetchLists();
+      refetch();
       // 成功メッセージはモーダル内から呼び出される
     };
 


### PR DESCRIPTION
## Summary
- `useMyLists` フックを新規作成し、`/api/v1/mylist` フェッチパターンを共通化
- `MyListIndexPage.tsx` と `AddToMyList.tsx` の重複する `lists/isLoading/error` state + `useEffect` を削除
- `useMyLists` から `setError` を公開し、フォームバリデーションエラーも同じ state で管理

## Test plan
- [ ] `npm run all` 全チェック通過 (front: 490, unit: 529)
- [ ] マイリスト一覧ページの表示・作成・編集・削除が正常動作
- [ ] 記事詳細ページの「マイリストに追加」モーダルが正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)