### PR TITLE
fix: pakParserをSimutrans本体との比較で改善

### DIFF
--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/BridgeParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/BridgeParser.php
@@ -45,6 +45,7 @@ class BridgeParser implements TypeParserInterface
                 7, 8 => $this->parseVersion7And8($binaryData, $offset, $stamp->version),
                 9 => $this->parseVersion9($binaryData, $offset),
                 10 => $this->parseVersion10($binaryData, $offset),
+                11 => $this->parseVersion11($binaryData, $offset),
                 default => throw new RuntimeException('Unsupported bridge version: '.$stamp->version),
             };
         }
@@ -625,6 +626,100 @@ class BridgeParser implements TypeParserInterface
             throw new RuntimeException('Failed to read number_of_seasons');
         }
 
+        $result['number_of_seasons'] = $seasonsData[1];
+
+        return $this->buildResult($result);
+    }
+
+    /**
+     * Parse version 11 (adds clip_below)
+     *
+     * @return array<string, mixed>
+     */
+    private function parseVersion11(string $binaryData, int $offset): array
+    {
+        $result = ['version' => 11];
+
+        $topspeedData = unpack('v', substr($binaryData, $offset, 2));
+        if ($topspeedData === false) {
+            throw new RuntimeException('Failed to read topspeed');
+        }
+        $result['topspeed'] = $topspeedData[1];
+        $offset += 2;
+
+        $result['price'] = BinaryReader::unpackSint64($binaryData, $offset);
+        $offset += 8;
+
+        $result['maintenance'] = BinaryReader::unpackSint64($binaryData, $offset);
+        $offset += 8;
+
+        $wtypData = unpack('C', substr($binaryData, $offset, 1));
+        if ($wtypData === false) {
+            throw new RuntimeException('Failed to read wtyp');
+        }
+        $result['waytype'] = $wtypData[1];
+        $offset += 1;
+
+        $pillarsData = unpack('C', substr($binaryData, $offset, 1));
+        if ($pillarsData === false) {
+            throw new RuntimeException('Failed to read pillars_every');
+        }
+        $result['pillars_every'] = $pillarsData[1];
+        $offset += 1;
+
+        $maxLengthData = unpack('C', substr($binaryData, $offset, 1));
+        if ($maxLengthData === false) {
+            throw new RuntimeException('Failed to read max_length');
+        }
+        $result['max_length'] = $maxLengthData[1];
+        $offset += 1;
+
+        $introDateData = unpack('v', substr($binaryData, $offset, 2));
+        if ($introDateData === false) {
+            throw new RuntimeException('Failed to read intro_date');
+        }
+        $result['intro_date'] = $introDateData[1];
+        $offset += 2;
+
+        $retireDateData = unpack('v', substr($binaryData, $offset, 2));
+        if ($retireDateData === false) {
+            throw new RuntimeException('Failed to read retire_date');
+        }
+        $result['retire_date'] = $retireDateData[1];
+        $offset += 2;
+
+        $asymmetricData = unpack('C', substr($binaryData, $offset, 1));
+        if ($asymmetricData === false) {
+            throw new RuntimeException('Failed to read pillars_asymmetric');
+        }
+        $result['pillars_asymmetric'] = $asymmetricData[1] !== 0;
+        $offset += 1;
+
+        $axleLoadData = unpack('v', substr($binaryData, $offset, 2));
+        if ($axleLoadData === false) {
+            throw new RuntimeException('Failed to read axle_load');
+        }
+        $result['axle_load'] = $axleLoadData[1];
+        $offset += 2;
+
+        $maxHeightData = unpack('C', substr($binaryData, $offset, 1));
+        if ($maxHeightData === false) {
+            throw new RuntimeException('Failed to read max_height');
+        }
+        $result['max_height'] = $maxHeightData[1];
+        $offset += 1;
+
+        $clipBelowData = unpack('C', substr($binaryData, $offset, 1));
+        if ($clipBelowData === false) {
+            throw new RuntimeException('Failed to read clip_below');
+        }
+        $result['clip_below'] = $clipBelowData[1] !== 0;
+        $offset += 1;
+
+        $seasonsData = unpack('C', substr($binaryData, $offset, 1));
+        if ($seasonsData === false) {
+            throw new RuntimeException('Failed to read number_of_seasons');
+        }
         $result['number_of_seasons'] = $seasonsData[1];
 
         return $this->buildResult($result);

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/VehicleParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/VehicleParser.php
@@ -46,6 +46,7 @@ class VehicleParser implements TypeParserInterface
                 10 => $this->parseVersion10($reader),
                 11 => $this->parseVersion11($reader),
                 12 => $this->parseVersion12($reader),
+                13 => $this->parseVersion13($reader),
                 default => [],
             };
 
@@ -296,6 +297,47 @@ class VehicleParser implements TypeParserInterface
         $reader->readUint32LE(); // upper 32 bits
         $capacity = $reader->readUint16LE();
         $loadingTime = $reader->readUint16LE();
+        $topspeed = $reader->readUint16LE();
+        $weight = $reader->readUint32LE();
+        $axleLoad = $reader->readUint16LE();
+        $power = $reader->readUint32LE();
+        $runningCost = $reader->readUint32LE();
+        $reader->readUint32LE(); // upper 32 bits
+        $maintenance = $reader->readUint32LE();
+        $reader->readUint32LE(); // upper 32 bits
+
+        return [
+            'price' => $price,
+            'capacity' => $capacity,
+            'loading_time' => $loadingTime,
+            'topspeed' => $topspeed,
+            'weight' => $weight,
+            'axle_load' => $axleLoad,
+            'power' => $power,
+            'running_cost' => $runningCost,
+            'maintenance' => $maintenance,
+            'intro_date' => $reader->readUint16LE(),
+            'retire_date' => $reader->readUint16LE(),
+            'gear' => $reader->readUint16LE(),
+            'waytype' => $reader->readUint8(),
+            'sound' => $reader->readUint8(),
+            'engine_type' => $reader->readUint8(),
+            'len' => $reader->readUint8(),
+            'leader_count' => $reader->readUint8(),
+            'trailer_count' => $reader->readUint8(),
+            'freight_image_type' => $reader->readUint8(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseVersion13(BinaryReader $reader): array
+    {
+        $price = $reader->readUint32LE();
+        $reader->readUint32LE(); // upper 32 bits
+        $capacity = $reader->readUint16LE();
+        $loadingTime = $reader->readUint32LE(); // uint32 (changed from uint16 in v12)
         $topspeed = $reader->readUint16LE();
         $weight = $reader->readUint32LE();
         $axleLoad = $reader->readUint16LE();

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/WayParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/WayParser.php
@@ -42,6 +42,7 @@ class WayParser implements TypeParserInterface
                 4, 5 => $this->parseVersion4And5($reader),
                 6 => $this->parseVersion6($reader),
                 7 => $this->parseVersion7($reader),
+                8 => $this->parseVersion8($reader),
                 default => [],
             };
 
@@ -54,6 +55,11 @@ class WayParser implements TypeParserInterface
             // axle_load defaults to 9999 for versions < 6
             if ($version < 6 && ! isset($data['axle_load'])) {
                 $data['axle_load'] = 9999;
+            }
+
+            // clip_below defaults based on waytype for versions < 8 (from way_reader.cc)
+            if ($version < 8) {
+                $data['clip_below'] = ($data['waytype'] ?? 0) !== 7; // 7 = powerline_wt
             }
 
             if (isset($data['styp'])) {
@@ -90,13 +96,17 @@ class WayParser implements TypeParserInterface
      */
     private function parseVersion1(BinaryReader $reader): array
     {
+        $price = $reader->readUint32LE();
+        $maintenance = $reader->readUint32LE();
+        $topspeed = $reader->readUint32LE();
+        $maxWeight = $reader->readUint32LE();
         $introDateRaw = $reader->readUint32LE();
 
         return [
-            'price' => $reader->readUint32LE(),
-            'maintenance' => $reader->readUint32LE(),
-            'topspeed' => $reader->readUint32LE(),
-            'max_weight' => $reader->readUint32LE(),
+            'price' => $price,
+            'maintenance' => $maintenance,
+            'topspeed' => $topspeed,
+            'max_weight' => $maxWeight,
             'intro_date' => intdiv($introDateRaw, 16) * 12 + ($introDateRaw % 16),
             'waytype' => $reader->readUint8(),
             'styp' => $reader->readUint8(),
@@ -204,6 +214,32 @@ class WayParser implements TypeParserInterface
             'waytype' => $reader->readUint8(),
             'styp' => $reader->readUint8(),
             'draw_as_obj' => $reader->readUint8(),
+            'number_of_seasons' => $reader->readSint8(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseVersion8(BinaryReader $reader): array
+    {
+        $price = $reader->readUint32LE();
+        $reader->readUint32LE(); // upper 32 bits
+        $maintenance = $reader->readUint32LE();
+        $reader->readUint32LE(); // upper 32 bits
+
+        return [
+            'price' => $price,
+            'maintenance' => $maintenance,
+            'topspeed' => $reader->readUint32LE(),
+            'max_weight' => $reader->readUint32LE(),
+            'intro_date' => $reader->readUint16LE(),
+            'retire_date' => $reader->readUint16LE(),
+            'axle_load' => $reader->readUint16LE(),
+            'waytype' => $reader->readUint8(),
+            'styp' => $reader->readUint8(),
+            'draw_as_obj' => $reader->readUint8(),
+            'clip_below' => $reader->readUint8(),
             'number_of_seasons' => $reader->readSint8(),
         ];
     }

--- a/tests/Unit/Services/FileInfo/Extractors/Pak/TypeParsers/BridgeParserTest.php
+++ b/tests/Unit/Services/FileInfo/Extractors/Pak/TypeParsers/BridgeParserTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\FileInfo\Extractors\Pak\TypeParsers;
+
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
+use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\TypeParsers\BridgeParser;
+use Tests\Unit\TestCase;
+
+class BridgeParserTest extends TestCase
+{
+    private BridgeParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new BridgeParser;
+    }
+
+    private function makeNode(string $data): Node
+    {
+        $size = strlen($data);
+        $binary = 'BRDG' . pack('v', 0) . pack('v', $size) . $data;
+
+        return Node::parse(new BinaryReader($binary));
+    }
+
+    /**
+     * v11 で clip_below フィールドが読み取れることを検証する。
+     *
+     * v10: clip_below なし (waytype で自動設定)
+     * v11: clip_below を明示的に読む (bridge_reader.cc:162)
+     */
+    public function test_version11_parses_clip_below_from_binary(): void
+    {
+        $data = pack('v', 0x800B);   // version stamp = 11 (bit 15 set)
+        $data .= pack('v', 100);    // topspeed
+        $data .= pack('P', 200000); // price (sint64)
+        $data .= pack('P', 1000);   // maintenance (sint64)
+        $data .= pack('C', 1);      // waytype (road)
+        $data .= pack('C', 2);      // pillars_every
+        $data .= pack('C', 5);      // max_length
+        $data .= pack('v', 23880);  // intro_date
+        $data .= pack('v', 24240);  // retire_date
+        $data .= pack('C', 0);      // pillars_asymmetric
+        $data .= pack('v', 15);     // axle_load
+        $data .= pack('C', 3);      // max_height
+        $data .= pack('C', 1);      // clip_below = true
+        $data .= pack('C', 2);      // number_of_seasons
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('clip_below', $result);
+        $this->assertTrue($result['clip_below']);
+    }
+
+    /**
+     * v11 の全フィールドが正しく読まれることを検証する。
+     */
+    public function test_version11_parses_all_fields_correctly(): void
+    {
+        $data = pack('v', 0x800B);   // version stamp = 11
+        $data .= pack('v', 120);    // topspeed
+        $data .= pack('P', 500000); // price (sint64)
+        $data .= pack('P', 2000);   // maintenance (sint64)
+        $data .= pack('C', 2);      // waytype (track)
+        $data .= pack('C', 4);      // pillars_every
+        $data .= pack('C', 10);     // max_length
+        $data .= pack('v', 23880);  // intro_date
+        $data .= pack('v', 24240);  // retire_date
+        $data .= pack('C', 1);      // pillars_asymmetric = true
+        $data .= pack('v', 20);     // axle_load
+        $data .= pack('C', 5);      // max_height
+        $data .= pack('C', 0);      // clip_below = false
+        $data .= pack('C', 1);      // number_of_seasons
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertSame(11, $result['version']);
+        $this->assertSame(120, $result['topspeed']);
+        $this->assertSame(500000, $result['price']);
+        $this->assertSame(2000, $result['maintenance']);
+        $this->assertSame(2, $result['waytype']);
+        $this->assertSame(4, $result['pillars_every']);
+        $this->assertSame(10, $result['max_length']);
+        $this->assertSame(23880, $result['intro_date']);
+        $this->assertSame(24240, $result['retire_date']);
+        $this->assertTrue($result['pillars_asymmetric']);
+        $this->assertSame(20, $result['axle_load']);
+        $this->assertSame(5, $result['max_height']);
+        $this->assertFalse($result['clip_below']);
+        $this->assertSame(1, $result['number_of_seasons']);
+    }
+
+    /**
+     * v10 は clip_below を持たないことを検証する (v11 との対比)。
+     */
+    public function test_version10_does_not_have_clip_below_key(): void
+    {
+        $data = pack('v', 0x800A);   // version stamp = 10
+        $data .= pack('v', 100);    // topspeed
+        $data .= pack('P', 200000); // price (sint64)
+        $data .= pack('P', 1000);   // maintenance (sint64)
+        $data .= pack('C', 1);      // waytype (road)
+        $data .= pack('C', 2);      // pillars_every
+        $data .= pack('C', 5);      // max_length
+        $data .= pack('v', 23880);  // intro_date
+        $data .= pack('v', 24240);  // retire_date
+        $data .= pack('C', 0);      // pillars_asymmetric
+        $data .= pack('v', 15);     // axle_load
+        $data .= pack('C', 3);      // max_height
+        $data .= pack('C', 1);      // number_of_seasons
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertArrayNotHasKey('clip_below', $result);
+    }
+}

--- a/tests/Unit/Services/FileInfo/Extractors/Pak/TypeParsers/VehicleParserTest.php
+++ b/tests/Unit/Services/FileInfo/Extractors/Pak/TypeParsers/VehicleParserTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\FileInfo\Extractors\Pak\TypeParsers;
+
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
+use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\TypeParsers\VehicleParser;
+use Tests\Unit\TestCase;
+
+class VehicleParserTest extends TestCase
+{
+    private VehicleParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new VehicleParser;
+    }
+
+    private function makeNode(string $data): Node
+    {
+        $size = strlen($data);
+        $binary = 'VHCL' . pack('v', 0) . pack('v', $size) . $data;
+
+        return Node::parse(new BinaryReader($binary));
+    }
+
+    /**
+     * v13 の loading_time が uint32 で読まれることを検証する。
+     *
+     * v12: loading_time = uint16 (最大 65535)
+     * v13: loading_time = uint32 (vehicle_reader.cc:57)
+     * uint16 最大値を超える値 (70000) で区別できる。
+     */
+    public function test_version13_loading_time_is_read_as_uint32(): void
+    {
+        $data = pack('v', 0x800D);   // version stamp = 13 (bit 15 set)
+        $data .= pack('V', 50000);  // price_lo
+        $data .= pack('V', 0);      // price_hi
+        $data .= pack('v', 10);     // capacity
+        $data .= pack('V', 70000);  // loading_time (uint32 — uint16 の最大値 65535 を超える値)
+        $data .= pack('v', 80);     // topspeed
+        $data .= pack('V', 5000);   // weight
+        $data .= pack('v', 10);     // axle_load
+        $data .= pack('V', 150);    // power
+        $data .= pack('V', 100);    // running_cost_lo
+        $data .= pack('V', 0);      // running_cost_hi
+        $data .= pack('V', 200);    // maintenance_lo
+        $data .= pack('V', 0);      // maintenance_hi
+        $data .= pack('v', 23880);  // intro_date (1990*12)
+        $data .= pack('v', 24240);  // retire_date (2020*12)
+        $data .= pack('v', 64);     // gear
+        $data .= pack('C', 1);      // waytype (road)
+        $data .= pack('C', 254);    // sound
+        $data .= pack('C', 1);      // engine_type (diesel)
+        $data .= pack('C', 8);      // len
+        $data .= pack('C', 0);      // leader_count
+        $data .= pack('C', 0);      // trailer_count
+        $data .= pack('C', 0);      // freight_image_type
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertSame(70000, $result['loading_time']);
+    }
+
+    /**
+     * v13 の全フィールドが正しく読まれることを検証する。
+     */
+    public function test_version13_parses_all_fields_correctly(): void
+    {
+        $data = pack('v', 0x800D);   // version stamp = 13 (bit 15 set)
+        $data .= pack('V', 50000);  // price_lo
+        $data .= pack('V', 0);      // price_hi
+        $data .= pack('v', 10);     // capacity
+        $data .= pack('V', 500);    // loading_time
+        $data .= pack('v', 80);     // topspeed
+        $data .= pack('V', 5000);   // weight
+        $data .= pack('v', 12);     // axle_load
+        $data .= pack('V', 150);    // power
+        $data .= pack('V', 100);    // running_cost_lo
+        $data .= pack('V', 0);      // running_cost_hi
+        $data .= pack('V', 200);    // maintenance_lo
+        $data .= pack('V', 0);      // maintenance_hi
+        $data .= pack('v', 23880);  // intro_date
+        $data .= pack('v', 24240);  // retire_date
+        $data .= pack('v', 64);     // gear
+        $data .= pack('C', 1);      // waytype (road)
+        $data .= pack('C', 254);    // sound
+        $data .= pack('C', 1);      // engine_type (diesel)
+        $data .= pack('C', 8);      // len
+        $data .= pack('C', 2);      // leader_count
+        $data .= pack('C', 3);      // trailer_count
+        $data .= pack('C', 1);      // freight_image_type
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertSame(50000, $result['price']);
+        $this->assertSame(10, $result['capacity']);
+        $this->assertSame(500, $result['loading_time']);
+        $this->assertSame(80, $result['topspeed']);
+        $this->assertSame(5000, $result['weight']);
+        $this->assertSame(12, $result['axle_load']);
+        $this->assertSame(150, $result['power']);
+        $this->assertSame(100, $result['running_cost']);
+        $this->assertSame(200, $result['maintenance']);
+        $this->assertSame(23880, $result['intro_date']);
+        $this->assertSame(24240, $result['retire_date']);
+        $this->assertSame(64, $result['gear']);
+        $this->assertSame(1, $result['waytype']);
+        $this->assertSame(254, $result['sound']);
+        $this->assertSame(1, $result['engine_type']);
+        $this->assertSame(8, $result['len']);
+        $this->assertSame(2, $result['leader_count']);
+        $this->assertSame(3, $result['trailer_count']);
+        $this->assertSame(1, $result['freight_image_type']);
+    }
+}

--- a/tests/Unit/Services/FileInfo/Extractors/Pak/TypeParsers/WayParserTest.php
+++ b/tests/Unit/Services/FileInfo/Extractors/Pak/TypeParsers/WayParserTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\FileInfo\Extractors\Pak\TypeParsers;
+
+use App\Services\FileInfo\Extractors\Pak\BinaryReader;
+use App\Services\FileInfo\Extractors\Pak\Node;
+use App\Services\FileInfo\Extractors\Pak\TypeParsers\WayParser;
+use Tests\Unit\TestCase;
+
+class WayParserTest extends TestCase
+{
+    private WayParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new WayParser;
+    }
+
+    private function makeNode(string $data): Node
+    {
+        $size = strlen($data);
+        $binary = "WAY\x00" . pack('v', 0) . pack('v', $size) . $data;
+
+        return Node::parse(new BinaryReader($binary));
+    }
+
+    /**
+     * v1 のフィールド読み込み順序バグの修正を検証する。
+     *
+     * バグ: intro_date を先頭(1フィールド目)に読んでいた。
+     * 正: price→maintenance→topspeed→max_weight→intro_date の順 (way_reader.cc:130-138)
+     */
+    public function test_version1_reads_fields_in_correct_order(): void
+    {
+        $data = pack('v', 1);         // version = 1
+        $data .= pack('V', 10000);   // price
+        $data .= pack('V', 2000);    // maintenance
+        $data .= pack('V', 100);     // topspeed
+        $data .= pack('V', 500);     // max_weight
+        $data .= pack('V', 31840);   // intro_date_raw (1990*16) → converted: (31840/16)*12 + (31840%16) = 23880
+        $data .= pack('C', 1);       // waytype (road)
+        $data .= pack('C', 0);       // styp (flat)
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertSame(10000, $result['price']);
+        $this->assertSame(2000, $result['maintenance']);
+        $this->assertSame(100, $result['topspeed']);
+        $this->assertSame(500, $result['max_weight']);
+        $this->assertSame(23880, $result['intro_date']);
+        $this->assertSame(1, $result['waytype']);
+    }
+
+    /**
+     * v8 で clip_below フィールドが読み取れることを検証する。
+     */
+    public function test_version8_parses_clip_below_from_binary(): void
+    {
+        $data = pack('v', 8);         // version = 8
+        $data .= pack('V', 100000);  // price_lo
+        $data .= pack('V', 0);       // price_hi
+        $data .= pack('V', 1000);    // maintenance_lo
+        $data .= pack('V', 0);       // maintenance_hi
+        $data .= pack('V', 120);     // topspeed
+        $data .= pack('V', 500);     // max_weight
+        $data .= pack('v', 23880);   // intro_date
+        $data .= pack('v', 24240);   // retire_date
+        $data .= pack('v', 15);      // axle_load
+        $data .= pack('C', 1);       // waytype (road)
+        $data .= pack('C', 0);       // styp (flat)
+        $data .= pack('C', 0);       // draw_as_obj
+        $data .= pack('C', 1);       // clip_below = true
+        $data .= pack('c', 0);       // number_of_seasons
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('clip_below', $result);
+        $this->assertSame(1, $result['clip_below']);
+        $this->assertSame(100000, $result['price']);
+        $this->assertSame(15, $result['axle_load']);
+    }
+
+    /**
+     * v8 未満では clip_below が waytype に基づいてデフォルト設定されることを検証する。
+     * 非 powerline (road) → clip_below = true
+     */
+    public function test_version7_clip_below_defaults_to_true_for_road(): void
+    {
+        $data = pack('v', 7);         // version = 7
+        $data .= pack('V', 0) . pack('V', 0);  // price sint64
+        $data .= pack('V', 0) . pack('V', 0);  // maintenance sint64
+        $data .= pack('V', 100);     // topspeed
+        $data .= pack('V', 500);     // max_weight
+        $data .= pack('v', 23880);   // intro_date
+        $data .= pack('v', 24240);   // retire_date
+        $data .= pack('v', 9999);    // axle_load
+        $data .= pack('C', 1);       // waytype (road = 1, not powerline)
+        $data .= pack('C', 0);       // styp
+        $data .= pack('C', 0);       // draw_as_obj
+        $data .= pack('c', 0);       // number_of_seasons
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('clip_below', $result);
+        $this->assertTrue((bool) $result['clip_below']);
+    }
+
+    /**
+     * v8 未満では clip_below が waytype に基づいてデフォルト設定されることを検証する。
+     * powerline (128 → 7) → clip_below = false
+     */
+    public function test_version7_clip_below_defaults_to_false_for_powerline(): void
+    {
+        $data = pack('v', 7);         // version = 7
+        $data .= pack('V', 0) . pack('V', 0);  // price sint64
+        $data .= pack('V', 0) . pack('V', 0);  // maintenance sint64
+        $data .= pack('V', 100);     // topspeed
+        $data .= pack('V', 500);     // max_weight
+        $data .= pack('v', 23880);   // intro_date
+        $data .= pack('v', 24240);   // retire_date
+        $data .= pack('v', 9999);    // axle_load
+        $data .= pack('C', 128);     // waytype = 128 (powerline raw → converted to 7 by applyInternalCorrections)
+        $data .= pack('C', 0);       // styp
+        $data .= pack('C', 0);       // draw_as_obj
+        $data .= pack('c', 0);       // number_of_seasons
+
+        $result = $this->parser->parse($this->makeNode($data));
+
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('clip_below', $result);
+        $this->assertFalse((bool) $result['clip_below']);
+    }
+}


### PR DESCRIPTION
## Summary

- **バグ修正** WayParser v1: フィールド読み込み順序が逆だった (`intro_date` を先頭に読んでいた) → `price→maintenance→topspeed→max_weight→intro_date` の正しい順に修正
- **機能追加** VehicleParser v13: `loading_time` が `uint16`→`uint32` になった最新バージョンに対応
- **機能追加** WayParser v8: `clip_below` フィールドを追加、v8未満では `waytype` に基づくデフォルト補完も追加
- **機能追加** BridgeParser v11: `clip_below` フィールドを追加

## 調査方法

Simutrans本体の最新 master ブランチ (`clonesite/`) を参照し、各 `*_reader.cc` と実装を比較して洗い出した。

## Test plan

- [ ] `php artisan test tests/Unit/Services/FileInfo/Extractors/Pak/` がグリーンであることを確認
- [ ] WayParserTest: v1 フィールド順序、v8 clip_below、v<8 デフォルト補完
- [ ] VehicleParserTest: v13 loading_time が uint32 として読まれること
- [ ] BridgeParserTest: v11 clip_below、v10 との差分

🤖 Generated with [Claude Code](https://claude.com/claude-code)