### PR TITLE
fix: OBJ_SOUND型コードバグ修正とskin系パーサーを正しい型コードに対応

### DIFF
--- a/app/Services/FileInfo/Extractors/Pak/Node.php
+++ b/app/Services/FileInfo/Extractors/Pak/Node.php
@@ -49,11 +49,19 @@ class Node
 
     public const string OBJ_PEDESTRIAN = 'PASS';
 
-    public const string OBJ_SOUND = 'SOND';
-
-    public const string OBJ_SKIN = 'SKIN';
+    public const string OBJ_SOUND = 'SOUN';
 
     public const string OBJ_CURSOR = 'CURS';
+
+    public const string OBJ_MENU = 'MENU';
+
+    public const string OBJ_SMOKE = 'SMOK';
+
+    public const string OBJ_SYMBOL = 'SYMB';
+
+    public const string OBJ_MISCIMAGES = 'MISC';
+
+    public const string OBJ_FIELD = 'FIEL';
 
     public const string OBJ_XREF = 'XREF';
 

--- a/app/Services/FileInfo/Extractors/Pak/ObjectTypeConverter.php
+++ b/app/Services/FileInfo/Extractors/Pak/ObjectTypeConverter.php
@@ -31,7 +31,12 @@ class ObjectTypeConverter
             Node::OBJ_CITYCAR, 'CCAR' => 'citycar', // CCAR is used by makeobj 60.8+
             Node::OBJ_PEDESTRIAN => 'pedestrian',
             Node::OBJ_SOUND => 'sound',
-            Node::OBJ_SKIN => 'skin',
+            Node::OBJ_MENU => 'menu',
+            Node::OBJ_CURSOR => 'cursor',
+            Node::OBJ_SYMBOL => 'symbol',
+            Node::OBJ_FIELD => 'field',
+            Node::OBJ_SMOKE => 'smoke',
+            Node::OBJ_MISCIMAGES => 'miscimages',
             default => sprintf('unknown_%s', $type),
         };
     }

--- a/app/Services/FileInfo/Extractors/Pak/TypeParsers/SkinParser.php
+++ b/app/Services/FileInfo/Extractors/Pak/TypeParsers/SkinParser.php
@@ -25,7 +25,14 @@ class SkinParser implements TypeParserInterface
 {
     public function canParse(Node $node): bool
     {
-        return $node->type === Node::OBJ_SKIN || $node->type === 'smoke';
+        return in_array($node->type, [
+            Node::OBJ_MENU,
+            Node::OBJ_CURSOR,
+            Node::OBJ_SYMBOL,
+            Node::OBJ_FIELD,
+            Node::OBJ_SMOKE,
+            Node::OBJ_MISCIMAGES,
+        ], true);
     }
 
     /**
@@ -37,12 +44,12 @@ class SkinParser implements TypeParserInterface
      */
     public function parse(Node $node): array
     {
-        // skin/smoke オブジェクトはデータフィールドを持たない
+        // skin系オブジェクトはデータフィールドを持たない
         // 画像のみが子ノード（image-list）に含まれる
         return [
             'version' => 0,
             'has_data' => false,
-            'object_subtype' => $node->type, // 'skin' または 'smoke'
+            'object_subtype' => $node->type,
         ];
     }
 }


### PR DESCRIPTION
## Summary

- `Node::OBJ_SOUND` の型コードを `'SOND'` → `'SOUN'` に修正（`objversion.h` 準拠）。この修正により `SoundParser` が実際の SOUN ノードを正しく認識するようになる
- `Node::OBJ_SKIN`（Simutrans に存在しない型コード）を削除し、`OBJ_MENU / OBJ_SMOKE / OBJ_SYMBOL / OBJ_MISCIMAGES / OBJ_FIELD` の各定数を追加
- `SkinParser::canParse` を MENU/CURS/SYMB/FIEL/SMOK/MISC の6種で判定するよう修正
- `ObjectTypeConverter` に skin 系の各型コード→文字列マッピングを追加

## Test plan

- [ ] 既存の全 Unit テストが通過すること (`php artisan test tests/Unit/Services/FileInfo/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)