### PR TITLE
feat: pakパーサーデータの表示を全項目対応

### DIFF
--- a/resources/js/__tests__/features/articles/pak/formatter.test.ts
+++ b/resources/js/__tests__/features/articles/pak/formatter.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAxleLoad,
+  formatBoolean,
+  formatBuildPrice,
+  formatClimates,
+  formatDate,
+  formatMaintenanceCost,
+  formatRunningCost,
+  formatSpeed,
+  formatWeight,
+} from "@/features/articles/components/pak/formatter";
+
+describe("formatter", () => {
+  describe("formatDate", () => {
+    it("年月に変換できる", () => {
+      expect(formatDate(1990 * 12)).toBe("1990/01");
+      expect(formatDate(1990 * 12 + 5)).toBe("1990/06");
+    });
+
+    it("0 または undefined は空文字を返す", () => {
+      expect(formatDate(0)).toBe("");
+      expect(formatDate(undefined)).toBe("");
+    });
+
+    it("999912以上は空文字を返す（引退なし）", () => {
+      expect(formatDate(999912)).toBe("");
+      expect(formatDate(999999)).toBe("");
+    });
+  });
+
+  describe("formatSpeed", () => {
+    it("km/hを付けて返す", () => {
+      expect(formatSpeed(120)).toBe("120 km/h");
+    });
+
+    it("undefinedは空文字を返す", () => {
+      expect(formatSpeed(undefined)).toBe("");
+    });
+  });
+
+  describe("formatWeight", () => {
+    it("kgをトンに変換する", () => {
+      expect(formatWeight(5000)).toBe("5.0 t");
+    });
+
+    it("undefinedは空文字を返す", () => {
+      expect(formatWeight(undefined)).toBe("");
+    });
+  });
+
+  describe("formatBuildPrice", () => {
+    it("×100して Cr 単位で返す", () => {
+      expect(formatBuildPrice(100)).toBe("10,000 Cr");
+    });
+  });
+
+  describe("formatRunningCost", () => {
+    it("÷100して Cr/km 単位で返す", () => {
+      expect(formatRunningCost(200)).toBe("2.00 Cr/km");
+    });
+  });
+
+  describe("formatMaintenanceCost", () => {
+    it("÷100して Cr/月 単位で返す", () => {
+      expect(formatMaintenanceCost(150)).toBe("1.50 Cr/月");
+    });
+  });
+
+  describe("formatBoolean", () => {
+    it("trueはYesを返す", () => {
+      expect(formatBoolean(true)).toBe("Yes");
+    });
+
+    it("falseはNoを返す", () => {
+      expect(formatBoolean(false)).toBe("No");
+    });
+
+    it("undefinedは空文字を返す", () => {
+      expect(formatBoolean(undefined)).toBe("");
+    });
+  });
+
+  describe("formatAxleLoad", () => {
+    it("通常の値はトン単位で返す", () => {
+      expect(formatAxleLoad(20)).toBe("20 t");
+    });
+
+    it("9999以上は無制限を返す", () => {
+      expect(formatAxleLoad(9999)).toBe("無制限");
+      expect(formatAxleLoad(10000)).toBe("無制限");
+    });
+
+    it("undefinedは空文字を返す", () => {
+      expect(formatAxleLoad(undefined)).toBe("");
+    });
+  });
+
+  describe("formatClimates", () => {
+    it("気候名を日本語に変換して返す", () => {
+      expect(formatClimates(["temperate_climate", "tundra_climate"])).toBe(
+        "温帯, ツンドラ"
+      );
+    });
+
+    it("全気候を変換できる", () => {
+      const allClimates = [
+        "water_climate",
+        "desert_climate",
+        "tropic_climate",
+        "mediterran_climate",
+        "temperate_climate",
+        "tundra_climate",
+        "rocky_climate",
+        "arctic_climate",
+      ];
+      const result = formatClimates(allClimates);
+      expect(result).toBe("水域, 砂漠, 熱帯, 地中海性, 温帯, ツンドラ, 岩地, 極地");
+    });
+
+    it("空配列は空文字を返す", () => {
+      expect(formatClimates([])).toBe("");
+    });
+
+    it("undefinedは空文字を返す", () => {
+      expect(formatClimates(undefined)).toBe("");
+    });
+  });
+});

--- a/resources/js/__tests__/features/articles/pak/pakRowBuilders.test.ts
+++ b/resources/js/__tests__/features/articles/pak/pakRowBuilders.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import { buildDetailRows } from "@/features/articles/components/pak/pakRowBuilders";
+import type {
+  BridgeData,
+  GroundobjData,
+  SoundData,
+  TreeData,
+  TunnelData,
+  VehicleData,
+  WayData,
+} from "@/types/models";
+
+function labelOf(rows: ReturnType<typeof buildDetailRows>, label: string) {
+  return rows.find((r) => r.label === label)?.value;
+}
+
+describe("buildDetailRows", () => {
+  describe("vehicle", () => {
+    const base: VehicleData = {
+      waytype: 2,
+      engine_type: 2,
+      capacity: 200,
+      topspeed: 130,
+      price: 500,
+      running_cost: 120,
+      maintenance: 80,
+      power: 300,
+      gear: 64,
+      weight: 50000,
+      axle_load: 15,
+      len: 8,
+      loading_time: 2000,
+      leader_count: 1,
+      trailer_count: 3,
+      intro_date: 1990 * 12,
+      retire_date: 2020 * 12,
+    };
+
+    it("軸重を表示する", () => {
+      const rows = buildDetailRows("vehicle", base as Record<string, unknown>);
+      expect(labelOf(rows, "軸重")).toBe("15 t");
+    });
+
+    it("9999の軸重は無制限を表示する", () => {
+      const rows = buildDetailRows("vehicle", { ...base, axle_load: 9999 } as Record<string, unknown>);
+      expect(labelOf(rows, "軸重")).toBe("無制限");
+    });
+
+    it("乗降時間を表示する", () => {
+      const rows = buildDetailRows("vehicle", base as Record<string, unknown>);
+      expect(labelOf(rows, "乗降時間")).toBe("2000 ms");
+    });
+
+    it("維持費を表示する", () => {
+      const rows = buildDetailRows("vehicle", base as Record<string, unknown>);
+      expect(labelOf(rows, "維持費")).toBe("0.80 Cr/月");
+    });
+
+    it("先頭/付随連結可能数を表示する", () => {
+      const rows = buildDetailRows("vehicle", base as Record<string, unknown>);
+      expect(labelOf(rows, "先頭連結可能数")).toBe(1);
+      expect(labelOf(rows, "付随連結可能数")).toBe(3);
+    });
+  });
+
+  describe("way", () => {
+    const base: WayData = {
+      waytype: 2,
+      topspeed: 130,
+      max_weight: 500,
+      axle_load: 20,
+      price: 1000,
+      maintenance: 200,
+      number_of_seasons: 1,
+      clip_below: true,
+      intro_date: 1990 * 12,
+      retire_date: 2020 * 12,
+    };
+
+    it("最大重量を表示する", () => {
+      const rows = buildDetailRows("way", base as Record<string, unknown>);
+      expect(labelOf(rows, "最大重量")).toBe("500 t");
+    });
+
+    it("軸重制限を表示する", () => {
+      const rows = buildDetailRows("way", base as Record<string, unknown>);
+      expect(labelOf(rows, "軸重制限")).toBe("20 t");
+    });
+
+    it("下部クリップを表示する", () => {
+      const rows = buildDetailRows("way", base as Record<string, unknown>);
+      expect(labelOf(rows, "下部クリップ")).toBe("Yes");
+    });
+
+    it("clip_below=false はNoを表示する", () => {
+      const rows = buildDetailRows("way", { ...base, clip_below: false } as Record<string, unknown>);
+      expect(labelOf(rows, "下部クリップ")).toBe("No");
+    });
+  });
+
+  describe("bridge", () => {
+    const base: BridgeData = {
+      waytype: 2,
+      topspeed: 130,
+      axle_load: 25,
+      price: 2000,
+      maintenance: 300,
+      max_length: 10,
+      max_height: 5,
+      pillars_every: 4,
+      number_of_seasons: 1,
+      clip_below: false,
+      intro_date: 1990 * 12,
+      retire_date: 2020 * 12,
+    };
+
+    it("軸重制限を表示する", () => {
+      const rows = buildDetailRows("bridge", base as Record<string, unknown>);
+      expect(labelOf(rows, "軸重制限")).toBe("25 t");
+    });
+
+    it("最大高さを表示する", () => {
+      const rows = buildDetailRows("bridge", base as Record<string, unknown>);
+      expect(labelOf(rows, "最大高さ")).toBe(5);
+    });
+
+    it("支柱間隔をタイル単位で表示する", () => {
+      const rows = buildDetailRows("bridge", base as Record<string, unknown>);
+      expect(labelOf(rows, "支柱間隔")).toBe("4 タイル");
+    });
+
+    it("支柱間隔=0は支柱なしを表示する", () => {
+      const rows = buildDetailRows("bridge", { ...base, pillars_every: 0 } as Record<string, unknown>);
+      expect(labelOf(rows, "支柱間隔")).toBe("支柱なし");
+    });
+
+    it("下部クリップを表示する", () => {
+      const rows = buildDetailRows("bridge", base as Record<string, unknown>);
+      expect(labelOf(rows, "下部クリップ")).toBe("No");
+    });
+  });
+
+  describe("tunnel", () => {
+    const base: TunnelData = {
+      waytype: 2,
+      topspeed: 130,
+      axle_load: 30,
+      price: 3000,
+      maintenance: 400,
+      number_of_seasons: 0,
+      has_way: true,
+      broad_portals: false,
+      intro_date: 1990 * 12,
+      retire_date: 2020 * 12,
+    };
+
+    it("軸重制限を表示する", () => {
+      const rows = buildDetailRows("tunnel", base as Record<string, unknown>);
+      expect(labelOf(rows, "軸重制限")).toBe("30 t");
+    });
+
+    it("内部線路を表示する", () => {
+      const rows = buildDetailRows("tunnel", base as Record<string, unknown>);
+      expect(labelOf(rows, "内部線路")).toBe("Yes");
+    });
+
+    it("広口ポータルを表示する", () => {
+      const rows = buildDetailRows("tunnel", base as Record<string, unknown>);
+      expect(labelOf(rows, "広口ポータル")).toBe("No");
+    });
+  });
+
+  describe("tree", () => {
+    const base: TreeData = {
+      allowed_climates: 0x70,
+      climate_names: ["temperate_climate", "tundra_climate", "rocky_climate"],
+      distribution_weight: 5,
+      number_of_seasons: 1,
+    };
+
+    it("出現確率を表示する", () => {
+      const rows = buildDetailRows("tree", base as Record<string, unknown>);
+      expect(labelOf(rows, "出現確率（重み）")).toBe(5);
+    });
+
+    it("対応気候を日本語で表示する", () => {
+      const rows = buildDetailRows("tree", base as Record<string, unknown>);
+      expect(labelOf(rows, "対応気候")).toBe("温帯, ツンドラ, 岩地");
+    });
+
+    it("降雪対応を表示する", () => {
+      const rows = buildDetailRows("tree", base as Record<string, unknown>);
+      expect(labelOf(rows, "降雪対応")).toBe("Yes");
+    });
+  });
+
+  describe("groundobj", () => {
+    const base: GroundobjData = {
+      allowed_climates: 0x10,
+      climate_names: ["temperate_climate"],
+      distribution_weight: 3,
+      number_of_seasons: 0,
+      trees_on_top: true,
+      speed: 0,
+      waytype: 0,
+      price: 100,
+    };
+
+    it("出現確率を表示する", () => {
+      const rows = buildDetailRows("groundobj", base as Record<string, unknown>);
+      expect(labelOf(rows, "出現確率（重み）")).toBe(3);
+    });
+
+    it("対応気候を日本語で表示する", () => {
+      const rows = buildDetailRows("groundobj", base as Record<string, unknown>);
+      expect(labelOf(rows, "対応気候")).toBe("温帯");
+    });
+
+    it("speed=0は静止を表示する", () => {
+      const rows = buildDetailRows("groundobj", base as Record<string, unknown>);
+      expect(labelOf(rows, "移動速度")).toBe("静止");
+    });
+
+    it("上に木を生やせるをYesで表示する", () => {
+      const rows = buildDetailRows("groundobj", base as Record<string, unknown>);
+      expect(labelOf(rows, "上に木を生やせる")).toBe("Yes");
+    });
+  });
+
+  describe("sound", () => {
+    const base: SoundData = {
+      version: 2,
+      sound_id: 42,
+      filename: "horn.ogg",
+    };
+
+    it("サウンドIDを表示する", () => {
+      const rows = buildDetailRows("sound", base as Record<string, unknown>);
+      expect(labelOf(rows, "サウンドID")).toBe(42);
+    });
+
+    it("ファイル名を表示する", () => {
+      const rows = buildDetailRows("sound", base as Record<string, unknown>);
+      expect(labelOf(rows, "ファイル名")).toBe("horn.ogg");
+    });
+
+    it("filenameなしは空文字を表示する", () => {
+      const rows = buildDetailRows("sound", { ...base, filename: undefined } as Record<string, unknown>);
+      expect(labelOf(rows, "ファイル名")).toBe("");
+    });
+  });
+
+  describe("skin系 (menu/cursor/symbol/field/smoke/miscimages/ground)", () => {
+    it.each(["menu", "cursor", "symbol", "field", "smoke", "miscimages", "ground"])(
+      "%s は空の行配列を返す",
+      (type) => {
+        const rows = buildDetailRows(type, { has_data: false, object_subtype: type });
+        expect(rows).toHaveLength(0);
+      }
+    );
+  });
+});

--- a/resources/js/features/articles/components/pak/PakGenericMetadata.tsx
+++ b/resources/js/features/articles/components/pak/PakGenericMetadata.tsx
@@ -45,6 +45,15 @@ function getObjectTypeLabel(objectType: ObjectType): string {
     building: "建物",
     pedestrian: "歩行者",
     tree: "樹木",
+    groundobj: "地上オブジェクト",
+    ground: "地形テクスチャ",
+    sound: "効果音",
+    menu: "メニュー画像",
+    cursor: "カーソル画像",
+    symbol: "シンボル画像",
+    field: "フィールド画像",
+    smoke: "煙エフェクト",
+    miscimages: "その他画像",
   };
 
   return labels[objectType]

--- a/resources/js/features/articles/components/pak/formatter.ts
+++ b/resources/js/features/articles/components/pak/formatter.ts
@@ -153,6 +153,28 @@ export const formatBoolean = (value: boolean | undefined): string => {
   return value ? "Yes" : "No";
 };
 
+export const formatAxleLoad = (axle_load: number | undefined): string => {
+  if (axle_load === undefined) return "";
+  if (axle_load >= 9999) return "無制限";
+  return `${axle_load} t`;
+};
+
+const CLIMATE_NAME_TRANSLATIONS: Record<string, string> = {
+  water_climate: "水域",
+  desert_climate: "砂漠",
+  tropic_climate: "熱帯",
+  mediterran_climate: "地中海性",
+  temperate_climate: "温帯",
+  tundra_climate: "ツンドラ",
+  rocky_climate: "岩地",
+  arctic_climate: "極地",
+};
+
+export const formatClimates = (names: string[] | undefined): string => {
+  if (!names || names.length === 0) return "";
+  return names.map((n) => CLIMATE_NAME_TRANSLATIONS[n] || n).join(", ");
+};
+
 export const formatSignalType = (data: RoadsignData) => {
   return data.is_signal ? "信号" : "標識";
 };

--- a/resources/js/features/articles/components/pak/pakConstants.ts
+++ b/resources/js/features/articles/components/pak/pakConstants.ts
@@ -21,10 +21,19 @@ export type ObjectType =
   | "roadsign"
   | "crossing"
   | "tree"
+  | "groundobj"
+  | "ground"
   | "good"
   | "factory"
   | "citycar"
-  | "pedestrian";
+  | "pedestrian"
+  | "sound"
+  | "menu"
+  | "cursor"
+  | "symbol"
+  | "field"
+  | "smoke"
+  | "miscimages";
 
 /**
  * Waytype enum

--- a/resources/js/features/articles/components/pak/pakRowBuilders.ts
+++ b/resources/js/features/articles/components/pak/pakRowBuilders.ts
@@ -5,8 +5,11 @@ import type {
   CrossingData,
   FactoryData,
   GoodData,
+  GroundobjData,
   PedestrianData,
   RoadsignData,
+  SoundData,
+  TreeData,
   TunnelData,
   VehicleData,
   WayData,
@@ -20,8 +23,10 @@ import {
   getSystemTypeName,
 } from "./pakBuildingTranslations";
 import {
+  formatAxleLoad,
   formatBoolean,
   formatBuildPrice,
+  formatClimates,
   formatDate,
   formatEngineType,
   formatFreightType,
@@ -69,6 +74,20 @@ export function buildDetailRows(
       return buildCitycarRows(typeData as unknown as CitycarData);
     case "pedestrian":
       return buildPedestrianRows(typeData as unknown as PedestrianData);
+    case "tree":
+      return buildTreeRows(typeData as unknown as TreeData);
+    case "groundobj":
+      return buildGroundobjRows(typeData as unknown as GroundobjData);
+    case "sound":
+      return buildSoundRows(typeData as unknown as SoundData);
+    case "ground":
+    case "menu":
+    case "cursor":
+    case "symbol":
+    case "field":
+    case "smoke":
+    case "miscimages":
+      return [];
     default:
       return buildGenericRows(typeData);
   }
@@ -96,10 +115,15 @@ function buildVehicleRows(data: VehicleData): TableRow[] {
     { label: "輸送品目", value: formatFreightType(data.freight_type) },
     { label: "購入価格", value: formatBuildPrice(data.price) },
     { label: "運行費用", value: formatRunningCost(data.running_cost, 2) },
+    { label: "維持費", value: formatMaintenanceCost(data.maintenance) },
     { label: "出力", value: formatPower(data.power) },
     { label: "ギア", value: formatGear(data.gear) },
     { label: "重量", value: formatWeight(data.weight) },
+    { label: "軸重", value: formatAxleLoad(data.axle_load) },
     { label: "長さ", value: data.len },
+    { label: "乗降時間", value: data.loading_time !== undefined ? `${data.loading_time} ms` : "" },
+    { label: "先頭連結可能数", value: data.leader_count },
+    { label: "付随連結可能数", value: data.trailer_count },
     { label: "登場年月", value: formatDate(data.intro_date) },
     { label: "引退年月", value: formatDate(data.retire_date) },
   ];
@@ -110,11 +134,17 @@ function buildWayRows(data: WayData): TableRow[] {
     { label: "軌道タイプ", value: formatWaytype(data.waytype) },
     { label: "システムタイプ", value: getSystemTypeName(data.styp) },
     { label: "最高速度", value: formatSpeed(data.topspeed) },
+    { label: "最大重量", value: formatAxleLoad(data.max_weight) },
+    { label: "軸重制限", value: formatAxleLoad(data.axle_load) },
     { label: "建設費", value: formatBuildPrice(data.price) },
     { label: "維持費", value: formatMaintenanceCost(data.maintenance) },
     {
       label: "降雪対応",
       value: formatBoolean((data.number_of_seasons ?? 0) > 0),
+    },
+    {
+      label: "下部クリップ",
+      value: data.clip_below !== undefined ? formatBoolean(Boolean(data.clip_below)) : "",
     },
     { label: "登場年月", value: formatDate(data.intro_date) },
     { label: "引退年月", value: formatDate(data.retire_date) },
@@ -125,12 +155,24 @@ function buildBridgeRows(data: BridgeData): TableRow[] {
   return [
     { label: "軌道タイプ", value: formatWaytype(data.waytype) },
     { label: "最高速度", value: formatSpeed(data.topspeed) },
+    { label: "軸重制限", value: formatAxleLoad(data.axle_load) },
     { label: "建設費", value: formatBuildPrice(data.price) },
     { label: "維持費", value: formatMaintenanceCost(data.maintenance) },
     { label: "最大長", value: data.max_length || "無制限" },
+    { label: "最大高さ", value: data.max_height || "無制限" },
+    {
+      label: "支柱間隔",
+      value: data.pillars_every !== undefined
+        ? (data.pillars_every === 0 ? "支柱なし" : `${data.pillars_every} タイル`)
+        : "",
+    },
     {
       label: "降雪対応",
       value: formatBoolean((data.number_of_seasons ?? 0) > 0),
+    },
+    {
+      label: "下部クリップ",
+      value: data.clip_below !== undefined ? formatBoolean(data.clip_below) : "",
     },
     { label: "登場年月", value: formatDate(data.intro_date) },
     { label: "引退年月", value: formatDate(data.retire_date) },
@@ -141,11 +183,20 @@ function buildTunnelRows(data: TunnelData): TableRow[] {
   return [
     { label: "軌道タイプ", value: formatWaytype(data.waytype) },
     { label: "最高速度", value: formatSpeed(data.topspeed) },
+    { label: "軸重制限", value: formatAxleLoad(data.axle_load) },
     { label: "建設費", value: formatBuildPrice(data.price) },
     { label: "維持費", value: formatMaintenanceCost(data.maintenance) },
     {
       label: "降雪対応",
       value: formatBoolean((data.number_of_seasons ?? 0) > 0),
+    },
+    {
+      label: "内部線路",
+      value: data.has_way !== undefined ? formatBoolean(data.has_way) : "",
+    },
+    {
+      label: "広口ポータル",
+      value: data.broad_portals !== undefined ? formatBoolean(data.broad_portals) : "",
     },
     { label: "登場年月", value: formatDate(data.intro_date) },
     { label: "引退年月", value: formatDate(data.retire_date) },
@@ -160,6 +211,15 @@ function buildBuildingRows(data: BuildingData): TableRow[] {
     { label: "レベル", value: data.level || "" },
     { label: "サイズ", value: `${data.size_x || 1} x ${data.size_y || 1}` },
     { label: "レイアウト数", value: data.layouts || "" },
+    { label: "建設費", value: formatBuildPrice(data.price) },
+    { label: "維持費", value: formatMaintenanceCost(data.maintenance) },
+    {
+      label: "地下建設",
+      value:
+        data.allow_underground !== undefined
+          ? (["不可", "地下のみ", "地下/地上"][data.allow_underground] ?? "")
+          : "",
+    },
     { label: "登場年月", value: formatDate(data.intro_date) },
     { label: "引退年月", value: formatDate(data.retire_date) },
   ];
@@ -170,6 +230,7 @@ function buildFactoryRows(data: FactoryData): TableRow[] {
     { label: "生産力", value: data.productivity || "" },
     { label: "生産範囲", value: data.range || "" },
     { label: "出現確率（重み）", value: data.distribution_weight || "" },
+    { label: "旅客レベル", value: data.pax_level || "" },
     { label: "配置場所", value: getPlacementName(data.placement) },
     ...(data.input || []).map((item, index) => ({
       label: `入力貨物名${index + 1}`,
@@ -240,6 +301,7 @@ function buildCrossingRows(data: CrossingData): TableRow[] {
 function buildCitycarRows(data: CitycarData): TableRow[] {
   return [
     { label: "出現確率（重み）", value: data.distribution_weight },
+    { label: "最高速度", value: formatSpeed(data.topspeed) },
     { label: "登場年月", value: formatDate(data.intro_date) },
     { label: "引退年月", value: formatDate(data.retire_date) },
   ];
@@ -250,6 +312,45 @@ function buildPedestrianRows(data: PedestrianData): TableRow[] {
     { label: "出現確率（重み）", value: data.distribution_weight },
     { label: "登場年月", value: formatDate(data.intro_date) },
     { label: "引退年月", value: formatDate(data.retire_date) },
+  ];
+}
+
+function buildTreeRows(data: TreeData): TableRow[] {
+  return [
+    { label: "出現確率（重み）", value: data.distribution_weight },
+    { label: "対応気候", value: formatClimates(data.climate_names) },
+    {
+      label: "降雪対応",
+      value: formatBoolean((data.number_of_seasons ?? 0) > 0),
+    },
+  ];
+}
+
+function buildGroundobjRows(data: GroundobjData): TableRow[] {
+  return [
+    { label: "出現確率（重み）", value: data.distribution_weight },
+    { label: "対応気候", value: formatClimates(data.climate_names) },
+    {
+      label: "降雪対応",
+      value: formatBoolean((data.number_of_seasons ?? 0) > 0),
+    },
+    {
+      label: "移動速度",
+      value: data.speed === 0 ? "静止" : `${data.speed}`,
+    },
+    { label: "移動地形", value: formatWaytype(data.waytype) },
+    { label: "撤去費用", value: formatBuildPrice(data.price) },
+    {
+      label: "上に木を生やせる",
+      value: formatBoolean(data.trees_on_top),
+    },
+  ];
+}
+
+function buildSoundRows(data: SoundData): TableRow[] {
+  return [
+    { label: "サウンドID", value: data.sound_id },
+    { label: "ファイル名", value: data.filename || "" },
   ];
 }
 

--- a/resources/js/types/models/FileInfo.ts
+++ b/resources/js/types/models/FileInfo.ts
@@ -83,6 +83,8 @@ export interface WayData extends BaseObj {
   number_of_seasons?: number;
   /** 前面画像の有無 (version > 4) */
   front_images?: boolean;
+  /** 下部クリップ (v8+: uint8, v<8: waytype!=powerline) */
+  clip_below?: boolean | number;
 }
 
 /**
@@ -128,6 +130,8 @@ export interface BridgeData extends BaseObj {
   max_height?: number;
   /** 季節グラフィック数 (0 = なし, 1 = 雪あり) */
   number_of_seasons?: number;
+  /** 下部クリップ (v11+) */
+  clip_below?: boolean;
 }
 
 /**
@@ -211,8 +215,8 @@ export interface PedestrianData extends BaseObj {
 export interface TreeData extends BaseObj {
   /** 許可される気候（ビットマスク） / Allowed climates (bitmask) */
   allowed_climates: number;
-  /** 許可される気候（文字列） / Allowed climates (string) */
-  allowed_climates_str: string;
+  /** 許可される気候名（配列） / Allowed climate names (array) */
+  climate_names?: string[];
   /** 出現確率（重み） / Distribution weight (spawn probability) */
   distribution_weight: number;
   /** 季節数（0=旧形式） / Number of seasons (0=old format) */
@@ -225,8 +229,8 @@ export interface TreeData extends BaseObj {
 export interface GroundobjData extends BaseObj {
   /** 許可される気候（ビットマスク） / Allowed climates (bitmask) */
   allowed_climates: number;
-  /** 許可される気候（文字列） / Allowed climates (string) */
-  allowed_climates_str: string;
+  /** 許可される気候名（配列） / Allowed climate names (array) */
+  climate_names?: string[];
   /** 出現確率（重み） / Distribution weight (spawn probability) */
   distribution_weight: number;
   /** 季節数 / Number of seasons */
@@ -265,7 +269,7 @@ export interface SoundData extends BaseObj {
 export interface SkinData extends BaseObj {
   /** データフィールドの有無（常にfalse） / Has data fields (always false) */
   has_data: boolean;
-  /** オブジェクトサブタイプ ('skin' または 'smoke') / Object subtype */
+  /** オブジェクトサブタイプ ('MENU','CURS','SYMB','FIEL','SMOK','MISC') / Object subtype */
   object_subtype: string;
 }
 


### PR DESCRIPTION
## Summary

- Tree・GroundObj・Sound・Skin系（MENU/CURS/SYMB/FIEL/SMOK/MISC）など表示関数がなかった型に行ビルダーを追加
- 既存の Vehicle/Way/Bridge/Tunnel/Building/Factory/Citycar で未表示だったフィールドを追加
  - Vehicle: 軸重・乗降時間・維持費・先頭/付随連結可能数
  - Way: 最大重量・軸重制限・下部クリップ
  - Bridge: 軸重制限・最大高さ・支柱間隔・下部クリップ
  - Tunnel: 軸重制限・内部線路・広口ポータル
  - Building: 建設費・維持費・地下建設
  - Factory: 旅客レベル
  - Citycar: 最高速度
- `formatAxleLoad`（9999→無制限）・`formatClimates`（気候名→日本語）を追加
- TypeScript 型 (`FileInfo.ts`) に `clip_below`・`climate_names` フィールドを追加

## Test plan

- [ ] `npx vitest run resources/js/__tests__/features/articles/pak/` — 54件通過
- [ ] `npx tsc --noEmit` — 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)