### PR TITLE
chore: upgrade ramsey/composer-install from v3 to v4

### DIFF
--- a/.github/actions/php/action.yml
+++ b/.github/actions/php/action.yml
@@ -14,4 +14,4 @@ runs:
         php-version: ${{ inputs.php-version }}
         coverage: none
 
-    - uses: "ramsey/composer-install@v3"
+    - uses: "ramsey/composer-install@v4"


### PR DESCRIPTION
## Summary

- `ramsey/composer-install@v3` → `@v4`

v4.0.0 がリリースされていたため更新。他のアクションはすべてメジャーバージョンタグで最新に追従済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)