### PR TITLE
fix: address security audit findings (upload validation, MCP verified gate, fail-open flag)

### DIFF
--- a/app/Http/Controllers/Pages/Article/DownloadController.php
+++ b/app/Http/Controllers/Pages/Article/DownloadController.php
@@ -28,9 +28,11 @@ class DownloadController extends Controller
 
     public function conversion(Article $article, ConversionAction $conversionAction): RedirectResponse
     {
-        if (Gate::allows('conversion', $article)) {
-            $conversionAction($article, Auth::user());
+        if (Gate::denies('conversion', $article)) {
+            abort(404);
         }
+
+        $conversionAction($article, Auth::user());
 
         if ($article->contents instanceof AddonIntroductionContent && $article->contents->link) {
             return redirect($article->contents->link, Response::HTTP_FOUND);

--- a/app/Http/Requests/Attachment/StoreRequest.php
+++ b/app/Http/Requests/Attachment/StoreRequest.php
@@ -31,7 +31,10 @@ class StoreRequest extends FormRequest
         return [
             'file' => [
                 'required',
-                File::default()->extensions(self::ALLOWED_EXTENSIONS)->max('1gb'),
+                // .pak/.tab はSymfonyのMIME種別辞書に存在しないため mimes:/File::types() ではなく
+                // 拡張子ベースの extensions() で判定する。グローバルな File::defaults() の影響を受けないよう
+                // new File() で素の状態から組み立てる。
+                (new File)->extensions(self::ALLOWED_EXTENSIONS)->max('1gb'),
             ],
         ];
     }

--- a/app/Http/Requests/Attachment/StoreRequest.php
+++ b/app/Http/Requests/Attachment/StoreRequest.php
@@ -5,9 +5,22 @@ declare(strict_types=1);
 namespace App\Http\Requests\Attachment;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\File;
 
 class StoreRequest extends FormRequest
 {
+    /**
+     * Simutransアドオン・スクリーンショット・設定ファイルとして実運用されている拡張子のみ許可する。
+     *
+     * @var list<string>
+     */
+    private const ALLOWED_EXTENSIONS = [
+        'png', 'jpg', 'jpeg', 'jfif', 'ppm',
+        'zip', '7z',
+        'pak', 'tab',
+        'txt', 'pdf',
+    ];
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -16,7 +29,10 @@ class StoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'file' => ['required', 'file'],
+            'file' => [
+                'required',
+                File::default()->extensions(self::ALLOWED_EXTENSIONS)->max('1gb'),
+            ],
         ];
     }
 }

--- a/app/Models/ControllOption.php
+++ b/app/Models/ControllOption.php
@@ -70,6 +70,13 @@ class ControllOption extends Model
 
     private function isRestrict(ControllOptionKey $controllOptionKey): bool
     {
-        return $this->where(['key' => $controllOptionKey, 'value' => 0])->exists();
+        $option = $this->where('key', $controllOptionKey)->first();
+
+        // 行が存在しない場合は安全側に倒して制限する（fail-closed）。
+        if ($option === null) {
+            return true;
+        }
+
+        return ! $option->value;
     }
 }

--- a/app/Models/ControllOption.php
+++ b/app/Models/ControllOption.php
@@ -70,7 +70,7 @@ class ControllOption extends Model
 
     private function isRestrict(ControllOptionKey $controllOptionKey): bool
     {
-        $option = $this->where('key', $controllOptionKey)->first();
+        $option = self::where('key', $controllOptionKey)->first();
 
         // 行が存在しない場合は安全側に倒して制限する（fail-closed）。
         if ($option === null) {

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -25,9 +25,4 @@ class TagPolicy extends BasePolicy
 
         return $tag->editable;
     }
-
-    public function toggleEditable(User $user): bool
-    {
-        return $user->isAdmin();
-    }
 }

--- a/docs/security-audit-debt.md
+++ b/docs/security-audit-debt.md
@@ -1,0 +1,37 @@
+# Security Audit Debt
+
+Assurance Audit（web-security パック）で見つかった未解消のセキュリティ関連負債の台帳。
+解消したら表から行を削除し、本文末尾の解消ログに移動する。「未マージPR数」ではなく
+この表を棚卸し・監査の対象にする（`docs/dependency-debt.md` と同じ運用方針）。
+
+## 監査の前提
+
+- 実施日: 2026-06-21
+- 使用パック: web-security（authz/IDOR/レート制限/入力検証/データ露出）
+- **保護対象の振る舞いを管理する台帳は監査前には存在しなかった。** 本ファイルがその台帳の最初のバージョンになる。
+- 今回の監査では以下は調査対象外（次回監査で扱うべき候補）: SQL/コマンドインジェクション、格納型XSS、SSRF（Twitter OAuthコールバックが候補）、セッション固定化、メール/SMS再送スパム、マスアサインメントによる権限昇格、タイミング/404-vs-403によるユーザー存在列挙。
+
+## 未解消の負債（優先度順）
+
+（現時点で未解消の項目はありません。次回の監査でSQL/コマンドインジェクション、格納型XSS、SSRF、セッション固定化、メール/SMS再送スパム、マスアサインメント、ユーザー存在列挙を調査対象に追加する）
+
+## 解消ログ
+
+| # | 項目 | 対応内容 | 解消日 |
+|---|---|---|---|
+| 1 | 添付ファイルのアップロードに種別/サイズ制限なし | `app/Http/Requests/Attachment/StoreRequest.php` に実運用データ（添付ファイル2,573件の拡張子・サイズ実績）に基づく拡張子アローリスト（png/jpg/jpeg/jfif/ppm/zip/7z/pak/tab/txt/pdf）と1GBの上限を追加（`Illuminate\Validation\Rules\File::extensions()->max()`）。`.php`/`.exe`等の拒否、サイズ超過の拒否、許可拡張子（.pak/.tabを含む）の許可を検証する単体・機能テストを追加 | 2026-06-21 |
+| 2 | `/mcp/user` に `verified` ミドルウェアがない | `routes/ai.php` の `/mcp/user` ルートに `verified` ミドルウェアを追加。`tests/Feature/Mypage/TokenControllerTest.php` に未認証メールユーザーが403で拒否されることを検証するテスト（`test_mcp_rejects_unverified_user`）を追加 | 2026-06-21 |
+| 3 | `ControllOption::isRestrict()` がDB行欠落時にフェイルオープンする | `app/Models/ControllOption.php::isRestrict()` を、行が存在しない場合は安全側に倒して制限する（fail-closed）よう修正。`tests/Feature/Controllers/Auth/RegisterControllerTest.php` に `invitation_code` の設定行が存在しない場合に403になることを検証するテストを2件追加（招待ページ表示・登録の双方）。既存のFeatureテストは `ControllOptionsSeeder` で全キーが常にシードされるため影響なし | 2026-06-21 |
+| 4 | Redirect削除の所有権チェック（`RedirectController::destroy`）が未テスト | `tests/Feature/Controllers/Mypage/RedirectController/DestroyTest.php` を新規作成。本人による削除成功、未ログイン時の302リダイレクト、他人のRedirectは403で削除されないことの3パターンを検証 | 2026-06-21 |
+| 5 | 記事POST更新の所有権チェック（`EditController::update`）が未テスト | `tests/Feature/Controllers/Mypage/Article/UpdateTest.php` に `test_他人の記事は更新できない` を追加。他人がPOST更新を試みると403になり、記事のtitleが変更されないことを検証 | 2026-06-21 |
+| 6 | ログインレート制限・2FAバイパス防止が未テスト | `tests/Feature/Controllers/Fortify/LoginTest.php` に6回目のログイン失敗で429になることを検証するテストを追加。`tests/Feature/Controllers/Auth/TwoFactorControllerTest.php` に2FA有効ユーザーがパスワードのみではログイン完了せず（`two_factor: true` を返し未認証のまま）、正しいOTPコード入力後にのみ認証されることを検証するテストを追加 | 2026-06-21 |
+| 7 | 未公開記事のダウンロード/コンバージョンゲート・マイリスト非公開スラッグのアクセス制御が未テスト | テスト追加の過程で**実バグを発見・修正**：`app/Http/Controllers/Pages/Article/DownloadController.php::conversion()` は `Gate::allows()` の結果をカウント処理の有無にしか使っておらず、未公開記事でも `contents->link` が設定されていれば常にリダイレクトしていた（未公開記事のアドオンリンクが誰でも閲覧可能だった）。`Gate::denies()` で先に404を返すよう修正。`tests/Feature/Controllers/Pages/Article/DownloadControllerTest.php`（新規）でダウンロード/コンバージョン双方の未公開ケースを検証。マイリストは `tests/Feature/Controllers/Pages/PublicMyListController/ShowTest.php`・`ShowPublicTest.php`（新規）で非公開slugアクセスが404になることを確認（既存実装は元から正しく、テストのみ追加） | 2026-06-21 |
+| 8 | `TagPolicy::toggleEditable` が呼び出し元なし（デッドコード） | ユーザーに確認の上、削除を選択。アプリ・テスト双方に呼び出し元がないことを再確認してから `app/Policies/TagPolicy.php` から削除 | 2026-06-21 |
+| 9 | 添付ファイル削除の所有権テストがSPOF（Strongなテストが1件のみ） | `tests/Feature/Controllers/Mypage/AttachmentController/DestroyTest.php` に `test_他人のファイルは削除されずに残る` を追加し、403レスポンスのアサーションとDB未削除のアサーションを別テストに分離。単一テストの破損が唯一の防御線にならないようにした | 2026-06-21 |
+
+<!--
+運用メモ:
+- 各項目を実装したら、対応する行をこの表から削除し、上記「解消ログ」セクションに
+  「# | 項目 | 対応内容 | 解消日」の形式で1行追記する。
+- 新しい監査を実施した場合は「監査の前提」の実施日・調査対象外リストを更新する。
+-->

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -9,4 +9,4 @@ use Laravel\Mcp\Facades\Mcp;
 Mcp::web('/mcp', SimutransAddonPortalGuestServer::class);
 
 Mcp::web('/mcp/user', SimutransAddonPortalUserServer::class)
-    ->middleware('auth:sanctum');
+    ->middleware(['auth:sanctum', 'verified']);

--- a/tests/Feature/Controllers/Auth/RegisterControllerTest.php
+++ b/tests/Feature/Controllers/Auth/RegisterControllerTest.php
@@ -35,6 +35,13 @@ class RegisterControllerTest extends TestCase
         $testResponse->assertForbidden();
     }
 
+    public function test_show_invite_設定行が存在しない(): void
+    {
+        ControllOption::query()->where('key', ControllOptionKey::InvitationCode)->delete();
+        $testResponse = $this->get(route('user.invite', ['invitation_code' => $this->user->invitation_code]));
+        $testResponse->assertForbidden();
+    }
+
     public function test_show_invite_無効なユーザー(): void
     {
         $this->user->delete();
@@ -63,6 +70,18 @@ class RegisterControllerTest extends TestCase
     public function test_registration_機能無効(): void
     {
         ControllOption::updateOrCreate(['key' => ControllOptionKey::InvitationCode], ['value' => false]);
+        $testResponse = $this->post(route('user.registration', ['invitation_code' => $this->user->invitation_code]), [
+            'name' => 'example',
+            'email' => 'example@example.com',
+            'password' => 'example123456',
+            'agreement' => 'on',
+        ]);
+        $testResponse->assertForbidden();
+    }
+
+    public function test_registration_設定行が存在しない(): void
+    {
+        ControllOption::query()->where('key', ControllOptionKey::InvitationCode)->delete();
         $testResponse = $this->post(route('user.registration', ['invitation_code' => $this->user->invitation_code]), [
             'name' => 'example',
             'email' => 'example@example.com',

--- a/tests/Feature/Controllers/Auth/TwoFactorControllerTest.php
+++ b/tests/Feature/Controllers/Auth/TwoFactorControllerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Controllers\Auth;
 
+use App\Models\User;
+use PragmaRX\Google2FA\Google2FA;
 use Tests\Feature\TestCase;
 
 class TwoFactorControllerTest extends TestCase
@@ -13,5 +15,29 @@ class TwoFactorControllerTest extends TestCase
         $testResponse = $this->get(route('two-factor.login'));
 
         $testResponse->assertOk();
+    }
+
+    public function test_two_factor有効なユーザーはパスワードのみではログイン完了しない(): void
+    {
+        $google2fa = app(Google2FA::class);
+        $secret = $google2fa->generateSecretKey();
+
+        $user = User::factory()->create([
+            'password' => bcrypt('password'),
+            'two_factor_secret' => encrypt($secret),
+            'two_factor_confirmed_at' => now(),
+        ]);
+
+        $loginResponse = $this->postJson('/auth/login', ['email' => $user->email, 'password' => 'password']);
+
+        $loginResponse->assertOk();
+        $loginResponse->assertJson(['two_factor' => true]);
+        $this->assertGuest();
+
+        $code = $google2fa->getCurrentOtp($secret);
+        $confirmResponse = $this->postJson(route('two-factor.login.store'), ['code' => $code]);
+
+        $confirmResponse->assertNoContent();
+        $this->assertAuthenticatedAs($user);
     }
 }

--- a/tests/Feature/Controllers/Fortify/LoginTest.php
+++ b/tests/Feature/Controllers/Fortify/LoginTest.php
@@ -34,4 +34,18 @@ class LoginTest extends TestCase
         $testResponse = $this->postJson($this->url, ['email' => $user->email, 'password' => 'password']);
         $testResponse->assertForbidden();
     }
+
+    public function test_6回目のログイン失敗で429になる(): void
+    {
+        $user = User::factory()->create(['password' => bcrypt('password')]);
+
+        for ($i = 0; $i < 5; $i++) {
+            $testResponse = $this->postJson($this->url, ['email' => $user->email, 'password' => 'wrong-password']);
+            $testResponse->assertStatus(422);
+        }
+
+        $testResponse = $this->postJson($this->url, ['email' => $user->email, 'password' => 'wrong-password']);
+        $testResponse->assertStatus(429);
+        $this->assertGuest();
+    }
 }

--- a/tests/Feature/Controllers/Mypage/Article/UpdateTest.php
+++ b/tests/Feature/Controllers/Mypage/Article/UpdateTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Controllers\Mypage\Article;
 use App\Enums\ArticlePostType;
 use App\Enums\ArticleStatus;
 use App\Models\Article;
+use App\Models\User;
 use App\Notifications\SendArticlePublished;
 use App\Notifications\SendArticleUpdated;
 use Illuminate\Support\Facades\Notification;
@@ -29,6 +30,25 @@ class UpdateTest extends TestCase
 
         $testResponse = $this->postJson($url);
         $testResponse->assertUnauthorized();
+    }
+
+    public function test_他人の記事は更新できない(): void
+    {
+        $otherUser = User::factory()->create();
+        $url = '/api/v2/articles/'.$this->article->id;
+        $originalTitle = $this->article->title;
+
+        $this->actingAs($otherUser);
+
+        $testResponse = $this->postJson($url, [
+            'article' => $this->createArticle(),
+            'should_notify' => false,
+            'without_update_modified_at' => true,
+        ]);
+        $testResponse->assertForbidden();
+
+        $this->article->refresh();
+        $this->assertSame($originalTitle, $this->article->title);
     }
 
     public function test_更新通知する(): void

--- a/tests/Feature/Controllers/Mypage/AttachmentController/DestroyTest.php
+++ b/tests/Feature/Controllers/Mypage/AttachmentController/DestroyTest.php
@@ -34,6 +34,18 @@ class DestroyTest extends TestCase
         $testResponse->assertStatus(403);
     }
 
+    public function test_他人のファイルは削除されずに残る(): void
+    {
+        $othersUser = User::factory()->create();
+        $attachment = $this->createAttachment($othersUser);
+        $url = '/api/v2/attachments/'.$attachment->id;
+
+        $this->actingAs($this->user);
+        $this->deleteJson($url);
+
+        $this->assertNotNull(Attachment::find($attachment->id));
+    }
+
     public function test(): void
     {
         $url = '/api/v2/attachments/'.$this->attachment->id;

--- a/tests/Feature/Controllers/Mypage/AttachmentController/StoreTest.php
+++ b/tests/Feature/Controllers/Mypage/AttachmentController/StoreTest.php
@@ -41,4 +41,15 @@ class StoreTest extends TestCase
         $testResponse = $this->postJson($url, []);
         $testResponse->assertUnauthorized();
     }
+
+    public function test_許可されていない拡張子は拒否される(): void
+    {
+        $url = '/api/v2/attachments';
+
+        $this->actingAs($this->user);
+
+        $testResponse = $this->postJson($url, ['file' => UploadedFile::fake()->create('shell.php', 1)]);
+        $testResponse->assertUnprocessable();
+        $testResponse->assertJsonValidationErrors('file');
+    }
 }

--- a/tests/Feature/Controllers/Mypage/RedirectController/DestroyTest.php
+++ b/tests/Feature/Controllers/Mypage/RedirectController/DestroyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Mypage\RedirectController;
+
+use App\Models\Redirect;
+use App\Models\User;
+use Tests\Feature\TestCase;
+
+class DestroyTest extends TestCase
+{
+    public function test(): void
+    {
+        $user = User::factory()->create();
+        /** @var Redirect $redirect */
+        $redirect = Redirect::factory()->create(['user_id' => $user->id]);
+
+        $testResponse = $this->actingAs($user)->delete(route('mypage.redirects.destroy', $redirect));
+
+        $testResponse->assertRedirect(route('mypage.redirects'));
+        $this->assertDatabaseMissing('redirects', ['id' => $redirect->id]);
+    }
+
+    public function test_未ログイン(): void
+    {
+        /** @var Redirect $redirect */
+        $redirect = Redirect::factory()->create();
+
+        $testResponse = $this->delete(route('mypage.redirects.destroy', $redirect));
+
+        $testResponse->assertRedirect(route('login'));
+        $this->assertDatabaseHas('redirects', ['id' => $redirect->id]);
+    }
+
+    public function test_他人のリダイレクトは削除できない(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        /** @var Redirect $redirect */
+        $redirect = Redirect::factory()->create(['user_id' => $owner->id]);
+
+        $testResponse = $this->actingAs($otherUser)->delete(route('mypage.redirects.destroy', $redirect));
+
+        $testResponse->assertForbidden();
+        $this->assertDatabaseHas('redirects', ['id' => $redirect->id]);
+    }
+}

--- a/tests/Feature/Controllers/Pages/Article/DownloadControllerTest.php
+++ b/tests/Feature/Controllers/Pages/Article/DownloadControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Pages\Article;
+
+use App\Models\Article;
+use App\Models\Attachment;
+use Tests\Feature\TestCase;
+
+class DownloadControllerTest extends TestCase
+{
+    public function test_未公開記事はダウンロードできない(): void
+    {
+        $attachment = Attachment::factory()->create();
+        $article = Article::factory()->draft()->addonPost($attachment)->create();
+
+        $testResponse = $this->get(route('articles.download', ['article' => $article]));
+
+        $testResponse->assertNotFound();
+    }
+
+    public function test_未公開記事のコンバージョンはリダイレクトされない(): void
+    {
+        $article = Article::factory()->draft()->addonIntroduction()->create();
+
+        $testResponse = $this->get(route('articles.conversion', ['article' => $article]));
+
+        $testResponse->assertNotFound();
+    }
+
+    public function test_公開記事のコンバージョンはリダイレクトされる(): void
+    {
+        $article = Article::factory()->publish()->addonIntroduction()->create();
+
+        $testResponse = $this->get(route('articles.conversion', ['article' => $article]));
+
+        $testResponse->assertRedirect($article->contents->link);
+    }
+}

--- a/tests/Feature/Controllers/Pages/PublicMyListController/ShowPublicTest.php
+++ b/tests/Feature/Controllers/Pages/PublicMyListController/ShowPublicTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Pages\PublicMyListController;
+
+use App\Models\MyList;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\TestCase;
+
+class ShowPublicTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_公開リストはslugで表示できる(): void
+    {
+        $mylist = MyList::factory()->public()->create();
+
+        $res = $this->getJson("/api/v1/mylist/public/{$mylist->slug}");
+
+        $res->assertOk();
+        $res->assertJsonPath('list.id', $mylist->id);
+    }
+
+    public function test_非公開リストのslugは404になる(): void
+    {
+        $mylist = MyList::factory()->create([
+            'is_public' => false,
+            'slug' => 'private-list-slug',
+        ]);
+
+        $res = $this->getJson("/api/v1/mylist/public/{$mylist->slug}");
+
+        $res->assertNotFound();
+    }
+}

--- a/tests/Feature/Controllers/Pages/PublicMyListController/ShowTest.php
+++ b/tests/Feature/Controllers/Pages/PublicMyListController/ShowTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Pages\PublicMyListController;
+
+use App\Models\MyList;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_公開リストはslugで表示できる(): void
+    {
+        $mylist = MyList::factory()->public()->create();
+
+        $testResponse = $this->get(route('public-mylist.show', ['slug' => $mylist->slug]));
+
+        $testResponse->assertOk();
+    }
+
+    public function test_非公開リストのslugは404になる(): void
+    {
+        $mylist = MyList::factory()->create([
+            'is_public' => false,
+            'slug' => 'private-list-slug',
+        ]);
+
+        $testResponse = $this->get(route('public-mylist.show', ['slug' => $mylist->slug]));
+
+        $testResponse->assertNotFound();
+    }
+}

--- a/tests/Feature/Mypage/TokenControllerTest.php
+++ b/tests/Feature/Mypage/TokenControllerTest.php
@@ -118,4 +118,15 @@ class TokenControllerTest extends TestCase
 
         $this->assertNotEquals(401, $response->getStatusCode());
     }
+
+    public function test_mcp_rejects_unverified_user(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => null]);
+        $tokenResult = $user->createToken('MCP Token');
+
+        $response = $this->withToken($tokenResult->plainTextToken)
+            ->postJson('/mcp/user', []);
+
+        $response->assertForbidden();
+    }
 }

--- a/tests/Unit/Requests/Attachment/StoreRequestTest.php
+++ b/tests/Unit/Requests/Attachment/StoreRequestTest.php
@@ -35,12 +35,33 @@ class StoreRequestTest extends TestCase
             ['file' => 'test.zip'],
             'file',
         ];
+        yield '許可されていない拡張子(.php)' => [
+            ['file' => UploadedFile::fake()->create('shell.php', 1)],
+            'file',
+        ];
+        yield '許可されていない拡張子(.exe)' => [
+            ['file' => UploadedFile::fake()->create('malware.exe', 1)],
+            'file',
+        ];
+        yield 'サイズ上限(1GB)を超える' => [
+            ['file' => UploadedFile::fake()->create('test.zip', 1_000_001, 'application/zip')],
+            'file',
+        ];
     }
 
     public static function dataPass(): \Generator
     {
         yield '指定なしで通常ファイル' => [
             ['file' => UploadedFile::fake()->create('test.zip', 1, 'application/zip')],
+        ];
+        yield 'Simutransアドオンファイル(.pak)' => [
+            ['file' => UploadedFile::fake()->create('addon.pak', 1)],
+        ];
+        yield '設定ファイル(.tab)' => [
+            ['file' => UploadedFile::fake()->create('simuconf.tab', 1)],
+        ];
+        yield 'サイズ上限(1GB)以内' => [
+            ['file' => UploadedFile::fake()->create('test.zip', 1_000_000, 'application/zip')],
         ];
     }
 }


### PR DESCRIPTION
## Summary

Ran an Assurance Audit (web-security pack) against the app and recorded the findings as a living ledger in `docs/security-audit-debt.md`. All 9 identified items have been resolved.

Two of these were real vulnerabilities, not just missing tests:

- **Attachment upload had no file-type or size restriction** — any extension (including `.php`) and any size could be uploaded. Added an allowlist (`png/jpg/jpeg/jfif/ppm/zip/7z/pak/tab/txt/pdf`, derived from the actual extensions in use across 2,573 existing attachments) and a 1GB cap via `Illuminate\Validation\Rules\File`.
- **`DownloadController::conversion()` leaked unpublished articles' addon links** — the `Gate::allows('conversion', ...)` result only controlled whether the conversion was counted, not whether the redirect happened. An unpublished article's `contents->link` was reachable by anyone. Fixed to gate the redirect itself with `Gate::denies()`.

Other items fixed:

- `/mcp/user` route was missing the `verified` middleware that equivalent web mutation routes enforce — added it.
- `ControllOption::isRestrict()` failed open when a feature-flag row was missing from the DB (treated as "not restricted"). Changed to fail-closed.
- Added missing ownership/regression tests that existed only as inspection-verified-but-untested controls: Redirect destroy, Article POST update, login rate limiting (429 on 6th attempt), 2FA bypass prevention, MyList private-slug 404, and a second Attachment-destroy denial test (the prior single test was a SPOF).
- Removed `TagPolicy::toggleEditable` — confirmed dead code with no callers anywhere in the app or tests (user confirmed removal).

## Test plan

- [x] Full test suite passes (873 passed, 8 pre-existing skips, 0 failures)
- [x] `vendor/bin/pint --dirty` clean
- [x] Each fix has a dedicated regression test added in the same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)