### PR TITLE
fix: allow Dependabot PRs to pass OpenAPI validation CI

### DIFF
--- a/.github/workflows/openapi-docs.yml
+++ b/.github/workflows/openapi-docs.yml
@@ -22,8 +22,8 @@ jobs:
       - if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         uses: actions/checkout@v6
         with:
-          # Must be used to trigger workflow after push
-          token: ${{ secrets.ACCESS_TOKEN }}
+          # Must be used to trigger workflow after push; fallback to github.token for Dependabot (no access to secrets)
+          token: ${{ secrets.ACCESS_TOKEN || github.token }}
 
       - if: github.event.pull_request.head.repo.full_name != github.repository && github.event_name != 'push'
         uses: actions/checkout@v6
@@ -50,7 +50,7 @@ jobs:
         continue-on-error: true
 
       - name: Commit OpenAPI documentation
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+        if: (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push') && github.actor != 'dependabot[bot]'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[openapi] Update OpenAPI documentation"


### PR DESCRIPTION
## Summary

- `secrets.ACCESS_TOKEN` is not passed to Dependabot PRs by GitHub's design
- `actions/checkout@v7` (stricter than v6) rejects an empty token with _"Input required and not supplied: token"_, causing the **Validate OpenAPI Spec** check to fail on every Dependabot PR
- Fall back to `github.token` when `ACCESS_TOKEN` is unavailable
- Skip the auto-commit step for Dependabot PRs (no need to write OpenAPI docs back to a Dependabot-managed branch)

## Changes

- `.github/workflows/openapi-docs.yml`
  - Checkout token: `${{ secrets.ACCESS_TOKEN || github.token }}`
  - Commit step condition: added `&& github.actor != 'dependabot[bot]'`

## Test plan

- [ ] Merge this PR, then re-run a Dependabot PR (e.g. #518) to confirm Validate OpenAPI Spec passes
- [ ] Confirm the auto-commit step still fires normally on pushes to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)